### PR TITLE
#1071 FhirParser skips valid element

### DIFF
--- a/src/Hl7.Fhir.Serialization/FhirXmlNode.cs
+++ b/src/Hl7.Fhir.Serialization/FhirXmlNode.cs
@@ -173,7 +173,7 @@ namespace Hl7.Fhir.Serialization
             {
                 if (!PermissiveParsing) verifyXObject(scan, AllowedExternalNamespaces, this, this);
                 
-                if (scan.Name() != "value")
+                if (scan is XElement || scan.Name() != "value")
                 {
                     var scanName = scan.Name().LocalName;
                     bool isMatch = scanName.MatchesPrefix(name);


### PR DESCRIPTION
Added an extra check for FhirXmlNode. When PermissiveParsing is enabled for xmls parsing, the Value elements are not ignored anymore. This happened because of xmlns being not specified in the xml root and then the XElement "Value" was seen as XAttribute "Value".  

`if(scan is XElement)` is not enough (or better said it's too restrictive) as we could have the `<extension url =.. >` and then the url would be skipped.

Beside #1071, this PR should also solve the other items: #1121, #1131