### PR TITLE
#1130 Expression operators fail

### DIFF
--- a/src/Hl7.FhirPath.Tests/Tests/FhirPathGrammarTest.cs
+++ b/src/Hl7.FhirPath.Tests/Tests/FhirPathGrammarTest.cs
@@ -228,5 +228,15 @@ namespace Hl7.FhirPath.Tests
                         });
         }
 
+
+        [Fact]
+        public void FhirPath_Expression_Equals()
+        {
+            Expression x = new ConstantExpression("hi there");
+            Expression y = new VariableRefExpression("hi there");
+
+            Assert.False(x.Equals(y));
+            Assert.False(x == y);
+        }
     }
 }

--- a/src/Hl7.FhirPath/FhirPath/Expressions/ExpressionNode.cs
+++ b/src/Hl7.FhirPath/FhirPath/Expressions/ExpressionNode.cs
@@ -39,9 +39,9 @@ namespace Hl7.FhirPath.Expressions
         public abstract T Accept<T>(ExpressionVisitor<T> visitor, SymbolTable scope);
 
         public override bool Equals(object obj) => Equals(obj as Expression);
-        public bool Equals(Expression other) => this == other;
+        public bool Equals(Expression other) => other != null && this.GetType() == other?.GetType() && EqualityComparer<TypeInfo>.Default.Equals(ExpressionType, other.ExpressionType);
         public override int GetHashCode() => -28965461 + EqualityComparer<TypeInfo>.Default.GetHashCode(ExpressionType);
-        public static bool operator ==(Expression left, Expression right) => left?.GetType() == right?.GetType() && EqualityComparer<Expression>.Default.Equals(left, right);
+        public static bool operator ==(Expression left, Expression right) => EqualityComparer<Expression>.Default.Equals(left, right);
         public static bool operator !=(Expression left, Expression right) => !(left == right);
     }
 

--- a/src/Hl7.FhirPath/FhirPath/Expressions/ExpressionNode.cs
+++ b/src/Hl7.FhirPath/FhirPath/Expressions/ExpressionNode.cs
@@ -39,9 +39,9 @@ namespace Hl7.FhirPath.Expressions
         public abstract T Accept<T>(ExpressionVisitor<T> visitor, SymbolTable scope);
 
         public override bool Equals(object obj) => Equals(obj as Expression);
-        public bool Equals(Expression other) => other != null && EqualityComparer<TypeInfo>.Default.Equals(ExpressionType, other.ExpressionType);
+        public bool Equals(Expression other) => this == other;
         public override int GetHashCode() => -28965461 + EqualityComparer<TypeInfo>.Default.GetHashCode(ExpressionType);
-        public static bool operator ==(Expression left, Expression right) => EqualityComparer<Expression>.Default.Equals(left, right);
+        public static bool operator ==(Expression left, Expression right) => left?.GetType() == right?.GetType() && EqualityComparer<Expression>.Default.Equals(left, right);
         public static bool operator !=(Expression left, Expression right) => !(left == right);
     }
 


### PR DESCRIPTION
Fix: checking the types of the 2 Expressions is needed in order to avoid a positive result when comparing different types.
Equals method now just calls the == operator.
Unit test added.

https://github.com/FirelyTeam/fhir-net-api/issues/1130