### PR TITLE
1128 FhirPath expression node constructors should call its IEnumerable args only once

### DIFF
--- a/src/Hl7.FhirPath/FhirPath/Expressions/ExpressionNode.cs
+++ b/src/Hl7.FhirPath/FhirPath/Expressions/ExpressionNode.cs
@@ -118,7 +118,7 @@ namespace Hl7.FhirPath.Expressions
         public Expression Focus { get; private set; }
         public string FunctionName { get; private set; }
 
-        public Expression[] Arguments { get; private set; }
+        public IEnumerable<Expression> Arguments { get; private set; }
 
         public override T Accept<T>(ExpressionVisitor<T> visitor, SymbolTable scope)
         {

--- a/src/Hl7.FhirPath/FhirPath/Expressions/ExpressionNode.cs
+++ b/src/Hl7.FhirPath/FhirPath/Expressions/ExpressionNode.cs
@@ -112,13 +112,13 @@ namespace Hl7.FhirPath.Expressions
             if (String.IsNullOrEmpty(name)) throw Error.ArgumentNull("name");
             Focus = focus;
             FunctionName = name;
-            Arguments = arguments ?? throw Error.ArgumentNull("arguments");
+            Arguments = arguments != null ? arguments.ToArray() : throw Error.ArgumentNull("arguments");
         }
 
         public Expression Focus { get; private set; }
         public string FunctionName { get; private set; }
 
-        public IEnumerable<Expression> Arguments { get; private set; }
+        public Expression[] Arguments { get; private set; }
 
         public override T Accept<T>(ExpressionVisitor<T> visitor, SymbolTable scope)
         {


### PR DESCRIPTION
#1128
Changed the Argument type from IEnumerable to array avoiding multiple evaluation.