### PR TITLE
Support: faster EnumUtility.GetLiteral()

### DIFF
--- a/src/Hl7.Fhir.Support.Tests/Utility/EnumMappingTest.cs
+++ b/src/Hl7.Fhir.Support.Tests/Utility/EnumMappingTest.cs
@@ -9,7 +9,6 @@
 using System.Diagnostics;
 using Hl7.Fhir.Utility;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Hl7.Fhir.Model;
 
 namespace Hl7.Fhir.Support.Tests.Utils
 {
@@ -92,7 +91,6 @@ namespace Hl7.Fhir.Support.Tests.Utils
             Unknown,
         }
 
-
         [TestMethod]
         public void EnumParsingPerformance()
         {
@@ -119,6 +117,20 @@ namespace Hl7.Fhir.Support.Tests.Utils
             Assert.AreEqual("a", X.a.GetDocumentation()); // default documentation = name of item
         }
 
+        [TestMethod]
+        public void EnumLiteralPerformance()
+        {
+            var result = string.Empty;
+
+            var sw = Stopwatch.StartNew();
+            for (var i = 0; i < 50_000; i++)
+                result = TestAdministrativeGender.Male.GetLiteral();
+            sw.Stop();
+
+            Assert.AreEqual("male", result);
+            Debug.WriteLine(sw.ElapsedMilliseconds);
+            Assert.IsTrue(sw.ElapsedMilliseconds < 500);
+        }
 
         enum X
         {

--- a/src/Hl7.Fhir.Support/Utility/EnumUtility.cs
+++ b/src/Hl7.Fhir.Support/Utility/EnumUtility.cs
@@ -17,8 +17,7 @@ namespace Hl7.Fhir.Utility
     {
         public static string GetLiteral(this Enum e)
         {
-            var attr = e.GetAttributeOnEnum<EnumLiteralAttribute>();
-            return attr?.Literal ?? e.ToString();
+            return GetEnumMapping(e.GetType()).GetLiteral(e);
         }
 
         public static string GetSystem(this Enum e)


### PR DESCRIPTION
Instead of using reflection every time use the same cache used when parsing - it is more than 10 times faster

EnumUtility.GetLiteral() is called for every assignment to a Code property of a POCO (eg Patient.Gender) - so its performance is material for any application that creates a lot of POCO objects

Fixes https://github.com/FirelyTeam/fhir-net-api/issues/1169