### PR TITLE
Fix: now trims whitespaces of value attributes when serializing to xml

### DIFF
--- a/src/Hl7.Fhir.Serialization/FhirXmlBuilder.cs
+++ b/src/Hl7.Fhir.Serialization/FhirXmlBuilder.cs
@@ -103,7 +103,7 @@ namespace Hl7.Fhir.Serialization
             bool hasTypeInfo = serializationInfo != null;
 
             var value = source.Value != null ?
-                PrimitiveTypeConverter.ConvertTo<string>(source.Value) : null;
+                PrimitiveTypeConverter.ConvertTo<string>(source.Value).Trim() : null;
 
             // xhtml children require special treament:
             // - They don't use an xml "value" attribute to represent the value, instead their Value is inserted verbatim into the parent

--- a/src/Hl7.Fhir.Serialization/FhirXmlBuilder.cs
+++ b/src/Hl7.Fhir.Serialization/FhirXmlBuilder.cs
@@ -101,9 +101,14 @@ namespace Hl7.Fhir.Serialization
 
             if (!MustSerializeMember(source, out var serializationInfo)) return;
             bool hasTypeInfo = serializationInfo != null;
-
+            
             var value = source.Value != null ?
-                PrimitiveTypeConverter.ConvertTo<string>(source.Value).Trim() : null;
+                PrimitiveTypeConverter.ConvertTo<string>(source.Value) : null;
+
+            if(_settings.TrimWhitespaces)
+            {
+                value = value?.Trim();
+            }
 
             // xhtml children require special treament:
             // - They don't use an xml "value" attribute to represent the value, instead their Value is inserted verbatim into the parent

--- a/src/Hl7.Fhir.Serialization/FhirXmlSerializationSettings.cs
+++ b/src/Hl7.Fhir.Serialization/FhirXmlSerializationSettings.cs
@@ -44,6 +44,11 @@ namespace Hl7.Fhir.Serialization
         /// </summary>
         public bool AppendNewLine { get; set; } // = false;
 
+        /// <summary>
+        /// Trims whitespaces add the beginning and the end of xml value attributes
+        /// </summary>
+        public bool TrimWhitespaces { get; set; } = true;
+
         /// <summary>Default constructor. Creates a new <see cref="FhirXmlSerializationSettings"/> instance with default property values.</summary>
         public FhirXmlSerializationSettings() { }
 
@@ -65,6 +70,7 @@ namespace Hl7.Fhir.Serialization
             other.IgnoreUnknownElements = IgnoreUnknownElements;
             other.Pretty = Pretty;
             other.AppendNewLine = AppendNewLine;
+            other.TrimWhitespaces = TrimWhitespaces;
         }
 
         /// <summary>Creates a new <see cref="FhirXmlSerializationSettings"/> object that is a copy of the current instance.</summary>


### PR DESCRIPTION
https://github.com/FirelyTeam/fhir-net-api/issues/1176