### PR TITLE
Extra functionality for FhirPath to support TC 4.0.1

### DIFF
--- a/src/Hl7.FhirPath.Tests/Functions/CollectionOperatorsTests.cs
+++ b/src/Hl7.FhirPath.Tests/Functions/CollectionOperatorsTests.cs
@@ -1,0 +1,36 @@
+﻿using Hl7.Fhir.ElementModel;
+using Hl7.FhirPath.Functions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+
+namespace HL7.FhirPath.Tests.Functions
+{
+    [TestClass]
+    public class CollectionOperatorsTests
+    {
+        [TestMethod]
+        public void Intersect()
+        {
+            var a = ElementNode.ForPrimitive("A");
+            var b1 = ElementNode.ForPrimitive("B");
+            var c = ElementNode.ForPrimitive("C");
+            var b2 = ElementNode.ForPrimitive("B");
+
+            var col1 = new ITypedElement[] { a, b1 };
+            var col2 = new ITypedElement[] { c, b2 };
+            var col3 = new ITypedElement[] { c };
+
+            var result = col1.Intersect(col2);
+            Assert.IsNotNull(result);
+            Assert.AreEqual("B", result.First().Value);
+
+            result = col2.Intersect(col1);
+            Assert.IsNotNull(result);
+            Assert.AreEqual("B", result.First().Value);
+
+            result = col1.Intersect(col3);
+            Assert.IsNotNull(result);
+            Assert.IsFalse(result.Any());
+        }
+    }
+}

--- a/src/Hl7.FhirPath.Tests/Tests/FhirPathLexerTest.cs
+++ b/src/Hl7.FhirPath.Tests/Tests/FhirPathLexerTest.cs
@@ -6,12 +6,10 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/fhir-net-api/master/LICENSE
  */
 
-using System;
-using Hl7.FhirPath;
-using Hl7.FhirPath.Sprache;
-using Hl7.FhirPath.Parser;
-using Xunit;
 using Hl7.Fhir.Model.Primitives;
+using Hl7.FhirPath.Parser;
+using Hl7.FhirPath.Sprache;
+using Xunit;
 
 namespace Hl7.FhirPath.Tests
 {
@@ -62,9 +60,16 @@ namespace Hl7.FhirPath.Tests
 
             AssertParser.SucceedsMatch(parser, "A34", "A34");
             AssertParser.SucceedsMatch(parser, "\"A\uface%$#34\"", "A\uface%$#34");
+
+            SucceedsDelimitedString(parser, "`_Abcdef_ghijklmnopqrstuvwxyz_`");
+            SucceedsDelimitedString(parser, "\"_Abcdef_ghijklmnopqrstuvwxyz_\"");
+
             AssertParser.FailsMatch(parser, "34");
             AssertParser.FailsMatch(parser, "'Hello'");
             AssertParser.FailsMatch(parser, "@2013");
+            AssertParser.FailsMatch(parser, "`EndsWithDoubleQuote\"");
+
+
             //AssertParser.FailsMatch(parser, "true"); - this is an identifier, parser will only call in right context so no ambiguity
         }
 
@@ -83,7 +88,7 @@ namespace Hl7.FhirPath.Tests
             SucceedsPartialDateTime(parser, "@2015-01-02T12:34:00Z");
             SucceedsPartialDateTime(parser, "@2015-01-03T12:34:34+02:30");
             SucceedsPartialDateTime(parser, "@2015-01-03T12:34:34");
-      //      SucceedsPartialDateTime(parser, "@2015-01-01T23");  TODO: Make this work
+            //      SucceedsPartialDateTime(parser, "@2015-01-01T23");  TODO: Make this work
             AssertParser.FailsMatch(parser, "@2015-32-02T12:34:00Z");
             AssertParser.FailsMatch(parser, "@2015-01-02T28:34:00Z");
             AssertParser.FailsMatch(parser, "T12:34:34+02:30");
@@ -121,7 +126,7 @@ namespace Hl7.FhirPath.Tests
             AssertParser.FailsMatch(parser, "@T12:34:34+48:30");
         }
 
-            [Fact]
+        [Fact]
         public void FhirPath_Lex_Id()
         {
             var parser = Lexer.Id.End();
@@ -164,6 +169,22 @@ namespace Hl7.FhirPath.Tests
             AssertParser.FailsMatch(parser, @"'wrong es\qape'");
         }
 
+        [Fact]
+        public void FhirPath_Lex_DelimitedIdentifier()
+        {
+            var parser = Lexer.DelimitedIdentifier.End();
+
+            SucceedsDelimitedString(parser, "`2a`");
+            SucceedsDelimitedString(parser, "`_`");
+            SucceedsDelimitedString(parser, "`_Abcdef_ghijklmnopqrstuvwxyz_`");
+            SucceedsDelimitedString(parser, "`Hi \uface`");
+            SucceedsDelimitedString(parser, "`@#$%^&*().'`");
+            SucceedsDelimitedString(parser, "`3.1415`");
+
+            AssertParser.FailsMatch(parser, "`EndsWithDoubleQuote\"");
+            AssertParser.FailsMatch(parser, "NoQuotes");
+            AssertParser.FailsMatch(parser, @"'wrong es\qape'");
+        }
 
         [Fact]
         public void FhirPath_Lex_Unicode()
@@ -213,7 +234,7 @@ namespace Hl7.FhirPath.Tests
         [Fact]
         public void FhirPath_Lex_String()
         {
-            var parser = Lexer.String.End();            
+            var parser = Lexer.String.End();
 
             SucceedsDelimitedString(parser, @"'single quotes'");
             SucceedsDelimitedString(parser, @"'""single quotes with doubles""'");

--- a/src/Hl7.FhirPath/FhirPath/EvaluationContext.cs
+++ b/src/Hl7.FhirPath/FhirPath/EvaluationContext.cs
@@ -15,7 +15,7 @@ namespace Hl7.FhirPath
 
         public EvaluationContext(ITypedElement container) : this(container, null) { }
 
-        public EvaluationContext(ITypedElement container, ITypedElement rootContainer = null)
+        public EvaluationContext(ITypedElement container, ITypedElement rootContainer)
         {
             Container = container;
             RootContainer = rootContainer ?? container;

--- a/src/Hl7.FhirPath/FhirPath/EvaluationContext.cs
+++ b/src/Hl7.FhirPath/FhirPath/EvaluationContext.cs
@@ -13,10 +13,15 @@ namespace Hl7.FhirPath
             // no defaults yet
         }
 
-        public EvaluationContext(ITypedElement container)
+        public EvaluationContext(ITypedElement container) : this(container, null) { }
+
+        public EvaluationContext(ITypedElement container, ITypedElement rootContainer = null)
         {
             Container = container;
+            RootContainer = rootContainer ?? container;
         }
+
+        public ITypedElement RootContainer { get; set; }
 
         public ITypedElement Container { get; set; }
 

--- a/src/Hl7.FhirPath/FhirPath/Expressions/Closure.cs
+++ b/src/Hl7.FhirPath/FhirPath/Expressions/Closure.cs
@@ -7,8 +7,8 @@
  */
 
 
-using System.Collections.Generic;
 using Hl7.Fhir.ElementModel;
+using System.Collections.Generic;
 
 namespace Hl7.FhirPath.Expressions
 {
@@ -20,7 +20,7 @@ namespace Hl7.FhirPath.Expressions
 
         public EvaluationContext EvaluationContext { get; private set; }
 
-        public static Closure Root(ITypedElement root, EvaluationContext ctx=null)
+        public static Closure Root(ITypedElement root, EvaluationContext ctx = null)
         {
             var newContext = new Closure() { EvaluationContext = ctx ?? EvaluationContext.CreateDefault() };
 
@@ -28,7 +28,8 @@ namespace Hl7.FhirPath.Expressions
             newContext.SetThis(input);
             newContext.SetThat(input);
             newContext.SetOriginalContext(input);
-            if(ctx.Container != null) newContext.SetResource(new[] { ctx.Container } );
+            if (ctx.Container != null) newContext.SetResource(new[] { ctx.Container });
+            if (ctx.RootContainer != null) newContext.SetRootResource(new[] { ctx.RootContainer });
 
             return newContext;
         }

--- a/src/Hl7.FhirPath/FhirPath/Expressions/ClosureExtensions.cs
+++ b/src/Hl7.FhirPath/FhirPath/Expressions/ClosureExtensions.cs
@@ -6,8 +6,8 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/fhir-net-api/master/LICENSE
  */
 
-using System.Collections.Generic;
 using Hl7.Fhir.ElementModel;
+using System.Collections.Generic;
 
 namespace Hl7.FhirPath.Expressions
 {
@@ -52,6 +52,16 @@ namespace Hl7.FhirPath.Expressions
         public static void SetResource(this Closure ctx, IEnumerable<ITypedElement> value)
         {
             ctx.SetValue("resource", value);
+        }
+
+        public static IEnumerable<ITypedElement> GetRootResource(this Closure ctx)
+        {
+            return ctx.ResolveValue("rootResource");
+        }
+
+        public static void SetRootResource(this Closure ctx, IEnumerable<ITypedElement> value)
+        {
+            ctx.SetValue("rootResource", value);
         }
 
         public static Closure Nest(this Closure ctx, IEnumerable<ITypedElement> input)

--- a/src/Hl7.FhirPath/FhirPath/Expressions/EvaluatorVisitor.cs
+++ b/src/Hl7.FhirPath/FhirPath/Expressions/EvaluatorVisitor.cs
@@ -5,12 +5,12 @@
  * This file is licensed under the BSD 3-Clause license
  * available at https://raw.githubusercontent.com/FirelyTeam/fhir-net-api/master/LICENSE
  */
-using FP = Hl7.FhirPath.Expressions;
+using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.Utility;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Hl7.Fhir.Utility;
-using Hl7.Fhir.ElementModel;
+using FP = Hl7.FhirPath.Expressions;
 
 namespace Hl7.FhirPath.Expressions
 {
@@ -45,7 +45,7 @@ namespace Hl7.FhirPath.Expressions
         public override Invokee VisitVariableRef(FP.VariableRefExpression expression, SymbolTable scope)
         {
             // HACK, for now, $this is special, and we handle in run-time, not compile time...
-            if(expression.Name == "builtin.this")
+            if (expression.Name == "builtin.this")
                 return InvokeeFactory.GetThis;
 
             // HACK, for now, $this is special, and we handle in run-time, not compile time...
@@ -56,10 +56,13 @@ namespace Hl7.FhirPath.Expressions
             if (expression.Name == "context")
                 return InvokeeFactory.GetContext;
 
-            // HACK, for now, %context is special, and we handle in run-time, not compile time...
+            // HACK, for now, %resource is special, and we handle in run-time, not compile time...
             if (expression.Name == "resource")
                 return InvokeeFactory.GetResource;
 
+            // HACK, for now, %rootResource is special, and we handle in run-time, not compile time...
+            if (expression.Name == "rootResource")
+                return InvokeeFactory.GetRootResource;
 
             // Variables are still functions without arguments. For now variables are treated separately here,
             //Functions are handled elsewhere.
@@ -77,7 +80,7 @@ namespace Hl7.FhirPath.Expressions
                 // If we have multiple candidates, delay resolution to runtime
                 return (new DynaDispatcher(name, candidateTable).Dispatcher);
             }
-            else if(count == 1)
+            else if (count == 1)
             {
                 // There's only one candidate, again we don't have the right parameter types at
                 // to match yet.

--- a/src/Hl7.FhirPath/FhirPath/Expressions/Invokee.cs
+++ b/src/Hl7.FhirPath/FhirPath/Expressions/Invokee.cs
@@ -6,13 +6,12 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/fhir-net-api/master/LICENSE
  */
 
+using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.Utility;
 using Hl7.FhirPath.Functions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Hl7.Fhir.ElementModel;
-using Hl7.Fhir.Utility;
-using System.Reflection;
 
 namespace Hl7.FhirPath.Expressions
 {
@@ -36,6 +35,10 @@ namespace Hl7.FhirPath.Expressions
         public static IEnumerable<ITypedElement> GetResource(Closure context, IEnumerable<Invokee> arguments)
         {
             return context.GetResource();
+        }
+        public static IEnumerable<ITypedElement> GetRootResource(Closure context, IEnumerable<Invokee> arguments)
+        {
+            return context.GetRootResource();
         }
 
         public static IEnumerable<ITypedElement> GetThat(Closure context, IEnumerable<Invokee> args)

--- a/src/Hl7.FhirPath/FhirPath/Expressions/SymbolTableInit.cs
+++ b/src/Hl7.FhirPath/FhirPath/Expressions/SymbolTableInit.cs
@@ -6,13 +6,13 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/fhir-net-api/master/LICENSE
  */
 
-using System;
-using System.Linq;
-using System.Collections.Generic;
-using Hl7.FhirPath.Functions;
-using System.Text.RegularExpressions;
 using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Model.Primitives;
+using Hl7.FhirPath.Functions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace Hl7.FhirPath.Expressions
 {
@@ -34,6 +34,7 @@ namespace Hl7.FhirPath.Expressions
             t.Add("isDistinct", (IEnumerable<ITypedElement> f) => f.IsDistinct());
             t.Add("subsetOf", (IEnumerable<ITypedElement> f, IEnumerable<ITypedElement> a) => f.SubsetOf(a));
             t.Add("supersetOf", (IEnumerable<ITypedElement> f, IEnumerable<ITypedElement> a) => a.SubsetOf(f));
+            t.Add("intersect", (IEnumerable<ITypedElement> f, IEnumerable<ITypedElement> a) => f.Intersect(a));
 
             t.Add("today", (object f) => PartialDateTime.Today());
             t.Add("now", (object f) => PartialDateTime.Now());
@@ -44,13 +45,13 @@ namespace Hl7.FhirPath.Expressions
             t.Add("iif", (IEnumerable<ITypedElement> f, bool? condition, IEnumerable<ITypedElement> result, IEnumerable<ITypedElement> otherwise) => f.IIf(condition, result, otherwise));
 
             // Functions that use normal null propagation and work with the focus (buy may ignore it)
-            t.Add("not", (IEnumerable<ITypedElement> f) => f.Not(), doNullProp:true);
+            t.Add("not", (IEnumerable<ITypedElement> f) => f.Not(), doNullProp: true);
             t.Add("builtin.children", (IEnumerable<ITypedElement> f, string a) => f.Navigate(a), doNullProp: true);
 
             t.Add("children", (IEnumerable<ITypedElement> f) => f.Children(), doNullProp: true);
             t.Add("descendants", (IEnumerable<ITypedElement> f) => f.Descendants(), doNullProp: true);
 
-            t.Add("binary.=", (object f, IEnumerable<ITypedElement>  a, IEnumerable<ITypedElement> b) => a.IsEqualTo(b), doNullProp: true);
+            t.Add("binary.=", (object f, IEnumerable<ITypedElement> a, IEnumerable<ITypedElement> b) => a.IsEqualTo(b), doNullProp: true);
             t.Add("binary.!=", (object f, IEnumerable<ITypedElement> a, IEnumerable<ITypedElement> b) => !a.IsEqualTo(b), doNullProp: true);
             t.Add("binary.~", (object f, IEnumerable<ITypedElement> a, IEnumerable<ITypedElement> b) => a.IsEquivalentTo(b), doNullProp: true);
             t.Add("binary.!~", (object f, IEnumerable<ITypedElement> a, IEnumerable<ITypedElement> b) => !a.IsEquivalentTo(b), doNullProp: true);
@@ -104,7 +105,7 @@ namespace Hl7.FhirPath.Expressions
             t.Add("binary.>=", (object f, PartialTime a, PartialTime b) => a >= b, doNullProp: true);
 
             t.Add("single", (IEnumerable<ITypedElement> f) => f.Single(), doNullProp: true);
-            t.Add("skip", (IEnumerable<ITypedElement> f, long a) =>  f.Skip((int)a), doNullProp: true);
+            t.Add("skip", (IEnumerable<ITypedElement> f, long a) => f.Skip((int)a), doNullProp: true);
             t.Add("first", (IEnumerable<ITypedElement> f) => f.First(), doNullProp: true);
             t.Add("last", (IEnumerable<ITypedElement> f) => f.Last(), doNullProp: true);
             t.Add("tail", (IEnumerable<ITypedElement> f) => f.Tail(), doNullProp: true);

--- a/src/Hl7.FhirPath/FhirPath/Functions/CollectionOperators.cs
+++ b/src/Hl7.FhirPath/FhirPath/Functions/CollectionOperators.cs
@@ -6,10 +6,10 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/fhir-net-api/master/LICENSE
  */
 
-using System.Collections.Generic;
-using System.Linq;
 using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Utility;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Hl7.FhirPath.Functions
 {
@@ -81,6 +81,9 @@ namespace Hl7.FhirPath.Functions
         {
             return focus.All(fitem => other.Contains(fitem));
         }
+
+        public static IEnumerable<ITypedElement> Intersect(this IEnumerable<ITypedElement> focus, IEnumerable<ITypedElement> other)
+            => focus.Intersect(other, new EqualityOperators.ValueProviderEqualityComparer());
 
         public static IEnumerable<ITypedElement> Navigate(this IEnumerable<ITypedElement> elements, string name)
         {


### PR DESCRIPTION
This PR has extra functionality for FhirPath to support TC 4.0.1:
- new function `intersect()`
- supporting back tics (`) in identifier
- new environment variable `%rootResource`