### PR TITLE
Bugfix/1193 map primitive type

### DIFF
--- a/src/Hl7.Fhir.ElementModel/TypedElementOnSourceNode.cs
+++ b/src/Hl7.Fhir.ElementModel/TypedElementOnSourceNode.cs
@@ -153,9 +153,15 @@ namespace Hl7.Fhir.ElementModel
                     return TypeSpecifier.String;
                 default:
                     {
-                        var summary = Provider.Provide(fhirType);
-                        var type = summary.GetElements().Where(e => e.Type.Equals("value")).FirstOrDefault()?.Type.FirstOrDefault()?.GetTypeName();
-                        return tryMapFhirPrimitiveTypeToSystemType(type);
+                        // Check if a logical model uses a custom "primitive" data type based on FHIR data types
+                        if (Uri.IsWellFormedUriString(fhirType, UriKind.Absolute))
+                        {
+                            var summary = Provider.Provide(fhirType);
+                            var type = summary?.GetElements().Where(e => e.ElementName.Equals("value")).FirstOrDefault()?.Type.FirstOrDefault()?.GetTypeName();
+                            return tryMapFhirPrimitiveTypeToSystemType(type);
+                        }
+
+                        return null;
                     }
             }
         }


### PR DESCRIPTION
Solves https://github.com/FirelyTeam/fhir-net-api/issues/1193 for custom logical model data types. Separate PR on fhir-net-api with unit test proving that current behaviour was unaffected.