### PR TITLE
feature/1209 write logic to read also content from xml element

### DIFF
--- a/src/Hl7.Fhir.Serialization/XObjectFhirXmlExtensions.cs
+++ b/src/Hl7.Fhir.Serialization/XObjectFhirXmlExtensions.cs
@@ -79,9 +79,10 @@ namespace Hl7.Fhir.Serialization
         {
             if (current.AtXhtmlDiv())
                 return ((XElement)current).ToString(SaveOptions.DisableFormatting);
-            else
-                return current is XElement xelem ?
-                    xelem.Attribute("value")?.Value.Trim() : current.Value();
+            if (current.FirstChild() is XText) return current.Value();
+            return current is XElement xelem ?
+                xelem.Attribute("value")?.Value.Trim() : current.Value();
+            
         }
     }
 }


### PR DESCRIPTION
-GetValue Extension is now able to also read the content of an xml element if it´s exists. Otherwise it will take take the value attribute like always in fhir.

IssueNumber: #1209