### PR TITLE
#1312 Make resolvers & snapgen work asynchronously

### DIFF
--- a/src/Hl7.Fhir.ElementModel/Hl7.Fhir.ElementModel.csproj
+++ b/src/Hl7.Fhir.ElementModel/Hl7.Fhir.ElementModel.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>net45;net40;netstandard1.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.1;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\fhir-net-common.props" />

--- a/src/Hl7.Fhir.Serialization/Hl7.Fhir.Serialization.csproj
+++ b/src/Hl7.Fhir.Serialization/Hl7.Fhir.Serialization.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net45;net40;netstandard1.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.1;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\fhir-net-common.props" />

--- a/src/Hl7.Fhir.Support.Poco/Hl7.Fhir.Support.Poco.csproj
+++ b/src/Hl7.Fhir.Support.Poco/Hl7.Fhir.Support.Poco.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;net40;netstandard1.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.1;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\fhir-net-common.props" />

--- a/src/Hl7.Fhir.Support.Poco/Specification/Source/CachedResolver.cs
+++ b/src/Hl7.Fhir.Support.Poco/Specification/Source/CachedResolver.cs
@@ -43,7 +43,7 @@ namespace Hl7.Fhir.Specification.Source
         {
             Source = source as IResourceResolver;
 #pragma warning restore CS0618 // Type or member is obsolete
-            AsyncSource = source.AsAsync();
+            AsyncResolver = source.AsAsync();
             CacheDuration = cacheDuration;
 
             _resourcesByUri = new Cache<Resource>(id => InternalResolveByUri(id), CacheDuration);
@@ -51,13 +51,16 @@ namespace Hl7.Fhir.Specification.Source
         }
 
         /// <summary>
-        /// Returns the child source, as specified in the constructor.
+        /// Returns the resolver for which access is cached, as specified in the constructor.
         /// </summary>
         /// <remarks>May return <code>null</code> if the source is an exclusively asynchronous resolver.</remarks>
         [Obsolete("CachedResolver now works best with asynchronous resolvers. Use the AsyncSource property instead.")]
         public IResourceResolver Source { get; private set; }
 
-        public IAsyncResourceResolver AsyncSource { get; }
+        /// <summary>
+        /// Returns the resolver for which access is cached, as specified in the constructor.
+        /// </summary>
+        public IAsyncResourceResolver AsyncResolver { get; }
 
         /// <summary>Gets the default expiration time of a cache entry.</summary>
         public int CacheDuration { get; }
@@ -182,14 +185,14 @@ namespace Hl7.Fhir.Specification.Source
 
         internal async Task<Resource> InternalResolveByUri(string url)
         {
-            var resource = await AsyncSource.ResolveByUriAsync(url);
+            var resource = await AsyncResolver.ResolveByUriAsync(url);
             OnLoad(url, resource);
             return resource;
         }
 
         internal async Task<Resource> InternalResolveByCanonicalUri(string url)
         {
-            var resource = await AsyncSource.ResolveByCanonicalUriAsync(url);
+            var resource = await AsyncResolver.ResolveByCanonicalUriAsync(url);
             OnLoad(url, resource);
             return resource;
         }
@@ -198,7 +201,7 @@ namespace Hl7.Fhir.Specification.Source
         // http://blogs.msdn.com/b/jaredpar/archive/2011/03/18/debuggerdisplay-attribute-best-practices.aspx
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         internal protected virtual string DebuggerDisplay
-            => $"{GetType().Name} for {AsyncSource.DebuggerDisplayString()}";
+            => $"{GetType().Name} for {AsyncResolver.DebuggerDisplayString()}";
 
         private class Cache<T>
         {

--- a/src/Hl7.Fhir.Support.Poco/Specification/Source/CachedResolver.cs
+++ b/src/Hl7.Fhir.Support.Poco/Specification/Source/CachedResolver.cs
@@ -1,0 +1,293 @@
+﻿/* 
+ * Copyright (c) 2017, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ * 
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://github.com/FirelyTeam/fhir-net-api/blob/master/LICENSE
+ */
+
+using System;
+using Hl7.Fhir.Model;
+using System.Collections.Generic;
+using Hl7.Fhir.Utility;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace Hl7.Fhir.Specification.Source
+{
+    /// <summary>Defines options for the <see cref="CachedResolver"/> that determine how to load a resource.</summary>
+    public enum CachedResolverLoadingStrategy
+    {
+        /// <summary>Return from cache, if present. Otherwise (re-)load from source and update cache.</summary>
+        LoadOnDemand = 0,
+        /// <summary>Return from cache, if present. Do NOT (re-)load from source. Do NOT update cache.</summary>
+        LoadFromCache = 1,
+        /// <summary>Force (re-)load from source and update cache.</summary>
+        LoadFromSource = 2
+    }
+
+    /// <summary>Reads and caches FHIR artifacts (Profiles, ValueSets, ...) from an internal <see cref="IResourceResolver"/> instance.</summary>
+    public class CachedResolver : IResourceResolver, IAsyncResourceResolver
+    {
+        /// <summary>Default expiration time for cached entries.</summary>
+        public const int DEFAULT_CACHE_DURATION = 4 * 3600;     // 4 hours
+
+        readonly Cache<Resource> _resourcesByUri;
+        readonly Cache<Resource> _resourcesByCanonical;
+
+        /// <summary>Creates a new artifact resolver that caches loaded resources in memory.</summary>
+        /// <param name="source">Resolver from which artifacts are initially resolved on a cache miss.</param>
+        /// <param name="cacheDuration">Default expiration time of a cache entry, in seconds.</param>
+        public CachedResolver(IResourceResolver source, int cacheDuration = DEFAULT_CACHE_DURATION)
+        {
+            AsyncSource = source.ToAsync();
+#pragma warning disable CS0618 // Type or member is obsolete
+            Source = source;
+#pragma warning restore CS0618 // Type or member is obsolete
+            CacheDuration = cacheDuration;
+
+            _resourcesByUri = new Cache<Resource>(id => InternalResolveByUri(id), CacheDuration);
+            _resourcesByCanonical = new Cache<Resource>(id => InternalResolveByCanonicalUri(id), CacheDuration);
+        }
+
+        /// <summary>Returns a reference to the internal artifact source.</summary>
+        [Obsolete("CachedResolver now works best with asynchronous resolvers. Use the AsyncSource property instead.")]
+        public IResourceResolver Source { get; }
+
+        public IAsyncResourceResolver AsyncSource { get; }
+
+        /// <summary>Gets the default expiration time of a cache entry.</summary>
+        public int CacheDuration { get; }
+
+        [Obsolete("CachedResolver now works best with asynchronous resolvers. Use ResolveByUriAsync() instead.")]
+        public Resource ResolveByUri(string url) => TaskHelper.Await(() => ResolveByUriAsync(url));
+      
+        /// <summary>Retrieve the artifact with the specified url.</summary>
+        /// <param name="url">The url of the target artifact.</param>
+        /// <returns>A <see cref="Resource"/> instance, or <c>null</c> if unavailable.</returns>
+        /// <remarks>Return data from memory cache if available, otherwise load on demand from the internal artifact source.</remarks>
+        public async Task<Resource> ResolveByUriAsync(string url)
+        {
+            if (url == null) throw Error.ArgumentNull(nameof(url));
+            return await _resourcesByUri.Get(url, CachedResolverLoadingStrategy.LoadOnDemand);
+        }
+
+        [Obsolete("CachedResolver now works best with asynchronous resolvers. Use ResolveByUriAsync() instead.")]
+        public Resource ResolveByUri(string url, CachedResolverLoadingStrategy strategy) =>
+                TaskHelper.Await(() => ResolveByUriAsync(url, strategy));
+
+        /// <summary>Retrieve the artifact with the specified url.</summary>
+        /// <param name="url">The url of the target artifact.</param>
+        /// <param name="strategy">Option flag to control the loading strategy.</param>
+        /// <returns>A <see cref="Resource"/> instance, or <c>null</c> if unavailable.</returns>
+        /// <remarks>Return data from memory cache if available, otherwise load on demand from the internal artifact source.</remarks>
+        public async Task<Resource> ResolveByUriAsync(string url, CachedResolverLoadingStrategy strategy)
+        {
+            if (url == null) throw Error.ArgumentNull(nameof(url));
+            return await _resourcesByUri.Get(url, strategy);
+        }
+
+        [Obsolete("CachedResolver now works best with asynchronous resolvers. Use ResolveByCanonicalUriAsync() instead.")]
+        public Resource ResolveByCanonicalUri(string url) => TaskHelper.Await(() => ResolveByCanonicalUriAsync(url));
+
+        /// <summary>Retrieve the conformance resource with the specified canonical url.</summary>
+        /// <param name="url">The canonical url of the target conformance resource.</param>
+        /// <returns>A conformance <see cref="Resource"/> instance, or <c>null</c> if unavailable.</returns>
+        /// <remarks>Return data from memory cache if available, otherwise load on demand from the internal artifact source.</remarks>
+        public async Task<Resource> ResolveByCanonicalUriAsync(string url)
+        {
+            if (url == null) throw Error.ArgumentNull(nameof(url));
+            return await _resourcesByCanonical.Get(url, CachedResolverLoadingStrategy.LoadOnDemand);
+        }
+
+        [Obsolete("CachedResolver now works best with asynchronous resolvers. Use ResolveByCanonicalUriAsync() instead.")]
+        public Resource ResolveByCanonicalUri(string url, CachedResolverLoadingStrategy strategy) =>
+                TaskHelper.Await(() => ResolveByCanonicalUriAsync(url, strategy));
+
+        /// <summary>Retrieve the conformance resource with the specified canonical url.</summary>
+        /// <param name="url">The canonical url of the target conformance resource.</param>
+        /// <param name="strategy">Option flag to control the loading strategy.</param>
+        /// <returns>A conformance <see cref="Resource"/> instance, or <c>null</c> if unavailable.</returns>
+        /// <remarks>Return data from memory cache if available, otherwise load on demand from the internal artifact source.</remarks>
+        public async Task<Resource> ResolveByCanonicalUriAsync(string url, CachedResolverLoadingStrategy strategy)
+        {
+            if (url == null) throw Error.ArgumentNull(nameof(url));
+            return await _resourcesByCanonical.Get(url, strategy);
+        }
+
+        /// <summary>Clear the cache entry for the artifact with the specified url, if it exists.</summary>
+        /// <param name="url">The url of the target resource.</param>
+        /// <returns><c>true</c> if succesful, <c>false</c> otherwise.</returns>
+        public bool InvalidateByUri(string url)
+        {
+            if (url == null) throw Error.ArgumentNull(nameof(url));
+            return _resourcesByUri.Invalidate(url);
+        }
+
+        /// <summary>Clear the cache entry for the conformance resource with the specified canonical uri, if it exists.</summary>
+        /// <param name="url">The canonical url of the target conformance resource.</param>
+        /// <returns><c>true</c> if succesful, <c>false</c> otherwise.</returns>
+        public bool InvalidateByCanonicalUri(string url)
+        {
+            if (url == null) throw Error.ArgumentNull(nameof(url));
+            return _resourcesByCanonical.Invalidate(url);
+        }
+
+        /// <summary>Clear the memory cache by removing all existing cache entries.</summary>
+        public void Clear()
+        {
+            _resourcesByUri.Clear();
+            _resourcesByCanonical.Clear();
+        }
+
+        /// <summary>Determines if the memory cache contains a resource with the specified url.</summary>
+        /// <returns><c>true</c> if the resource is cached, or <c>false</c> otherwise.</returns>
+        public bool IsCachedUri(string url) => _resourcesByUri.Contains(url);
+
+        /// <summary>Determines if the memory cache contains a conformance resource with the specified canonical url.</summary>
+        /// <returns><c>true</c> if the conformance resource is cached, or <c>false</c> otherwise.</returns>
+        public bool IsCachedCanonicalUri(string url) => _resourcesByCanonical.Contains(url);
+
+        /// <summary>Event arguments for the <see cref="LoadResourceEventHandler"/> delegate.</summary>
+        public class LoadResourceEventArgs : EventArgs
+        {
+            public LoadResourceEventArgs(string url, Resource resource) : base()
+            {
+                Url = url;
+                Resource = resource;
+            }
+
+            /// <summary>Returns the url of the cached resource.</summary>
+            public string Url { get; }
+
+            /// <summary>Returns a reference to the cached resource.</summary>
+            public Resource Resource { get; }
+        }
+
+        /// <summary>Handles the <see cref="Load"/> event that is fired when a new resources is loaded into the cache.</summary>
+        public delegate void LoadResourceEventHandler(object sender, LoadResourceEventArgs e);
+
+        /// <summary>Occurs when a artifact is loaded into the cache.</summary>
+        public event LoadResourceEventHandler Load;
+
+        /// <summary>Called when an artifact is loaded into the cache.</summary>
+        protected virtual void OnLoad(string url, Resource resource) => Load?.Invoke(this, new LoadResourceEventArgs(url, resource));
+
+        internal async Task<Resource> InternalResolveByUri(string url)
+        {
+            var resource = await AsyncSource.ResolveByUriAsync(url);
+            OnLoad(url, resource);
+            return resource;
+        }
+
+        internal async Task<Resource> InternalResolveByCanonicalUri(string url)
+        {
+            var resource = await AsyncSource.ResolveByCanonicalUriAsync(url);
+            OnLoad(url, resource);
+            return resource;
+        }
+
+        // Allow derived classes to override
+        // http://blogs.msdn.com/b/jaredpar/archive/2011/03/18/debuggerdisplay-attribute-best-practices.aspx
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        internal protected virtual string DebuggerDisplay
+            => $"{GetType().Name} for {AsyncSource.DebuggerDisplayString()}";
+
+        private class Cache<T>
+        {
+            readonly Func<string, Task<T>> _onCacheMiss;
+            readonly int _duration;
+
+            readonly Object _getLock = new Object();
+            readonly Dictionary<string, CacheEntry<T>> _cache = new Dictionary<string, CacheEntry<T>>();
+
+            public Cache(Func<string, Task<T>> onCacheMiss, int duration)
+            {
+                _onCacheMiss = onCacheMiss;
+                _duration = duration;
+            }
+
+
+            public bool Contains(string identifier) =>
+                _cache.TryGetValue(identifier, out var entry) && !entry.IsExpired;
+
+            public async Task<T> Get(string identifier, CachedResolverLoadingStrategy strategy)
+            {
+                lock (_getLock)
+                {
+                    // Check the cache
+                    if (strategy != CachedResolverLoadingStrategy.LoadFromSource)
+                    {
+                        if (_cache.TryGetValue(identifier, out CacheEntry<T> entry))
+                        {
+                            // If we still have a fresh entry, return it
+                            if (!entry.IsExpired)
+                            {
+                                return entry.Data;
+                            }
+
+                            // Remove entry if it's too old
+                            _cache.Remove(identifier);
+                        }
+                    }
+                }
+
+                // Load from source
+                if (strategy != CachedResolverLoadingStrategy.LoadFromCache)
+                {
+                    // Otherwise, fetch it and cache it.
+                    T newData = await _onCacheMiss(identifier);
+
+                    lock (_getLock)
+                    {
+                        // finally double check whether some other thread has not created and added it by now, 
+                        // since we had to release the lock to run the async onCacheMiss.
+                        if (_cache.TryGetValue(identifier, out CacheEntry<T> existingEntry))
+                            return existingEntry.Data;
+                        else
+                        {
+                            // Add new entry or update existing entry
+                            _cache[identifier] = new CacheEntry<T>(newData, identifier, DateTimeOffset.UtcNow.AddSeconds(_duration));
+                            return newData;
+                        }
+                    }
+                }
+
+                return default(T);
+            }
+
+            public bool Invalidate(string identifier)
+            {
+                lock (_getLock)
+                {
+                    return _cache.Remove(identifier);
+                }
+            }
+
+            public void Clear()
+            {
+                lock (_getLock)
+                {
+                    _cache.Clear();
+                }
+            }
+        }
+
+        private class CacheEntry<T>
+        {
+            public readonly T Data;
+            public readonly string Identifier;
+            public readonly DateTimeOffset Expires;
+
+            public CacheEntry(T data, string identifier, DateTimeOffset expires)
+            {
+                Data = data;
+                Identifier = identifier;
+                Expires = expires;
+            }
+
+            /// <summary>Returns a boolean value that indicates if the cache entry is expired.</summary>
+            public bool IsExpired => DateTimeOffset.UtcNow > Expires;
+        }
+    }
+}

--- a/src/Hl7.Fhir.Support.Poco/Specification/Source/CachedResolver.cs
+++ b/src/Hl7.Fhir.Support.Poco/Specification/Source/CachedResolver.cs
@@ -38,19 +38,20 @@ namespace Hl7.Fhir.Specification.Source
         /// <summary>Creates a new artifact resolver that caches loaded resources in memory.</summary>
         /// <param name="source">Resolver from which artifacts are initially resolved on a cache miss.</param>
         /// <param name="cacheDuration">Default expiration time of a cache entry, in seconds.</param>
-        public CachedResolver(IResourceResolver source, int cacheDuration = DEFAULT_CACHE_DURATION)
-        {
-            AsyncSource = source.ToAsync();
 #pragma warning disable CS0618 // Type or member is obsolete
-            Source = source;
+        public CachedResolver(ISyncOrAsyncResourceResolver source, int cacheDuration = DEFAULT_CACHE_DURATION)
 #pragma warning restore CS0618 // Type or member is obsolete
+        {
+            AsyncSource = source.AsAsync();
             CacheDuration = cacheDuration;
 
             _resourcesByUri = new Cache<Resource>(id => InternalResolveByUri(id), CacheDuration);
             _resourcesByCanonical = new Cache<Resource>(id => InternalResolveByCanonicalUri(id), CacheDuration);
         }
 
-        /// <summary>Returns a reference to the internal artifact source.</summary>
+        /// <summary>
+        /// Returns the child source, if it was an synchronous resolver, otherwise <c>null</c>.
+        /// </summary>
         [Obsolete("CachedResolver now works best with asynchronous resolvers. Use the AsyncSource property instead.")]
         public IResourceResolver Source { get; }
 

--- a/src/Hl7.Fhir.Support.Poco/Specification/Source/CachedResolver.cs
+++ b/src/Hl7.Fhir.Support.Poco/Specification/Source/CachedResolver.cs
@@ -40,8 +40,9 @@ namespace Hl7.Fhir.Specification.Source
         /// <param name="cacheDuration">Default expiration time of a cache entry, in seconds.</param>
 #pragma warning disable CS0618 // Type or member is obsolete
         public CachedResolver(ISyncOrAsyncResourceResolver source, int cacheDuration = DEFAULT_CACHE_DURATION)
-#pragma warning restore CS0618 // Type or member is obsolete
         {
+            Source = source as IResourceResolver;
+#pragma warning restore CS0618 // Type or member is obsolete
             AsyncSource = source.AsAsync();
             CacheDuration = cacheDuration;
 
@@ -50,16 +51,18 @@ namespace Hl7.Fhir.Specification.Source
         }
 
         /// <summary>
-        /// Returns the child source, if it was an synchronous resolver, otherwise <c>null</c>.
+        /// Returns the child source, as specified in the constructor.
         /// </summary>
+        /// <remarks>May return <code>null</code> if the source is an exclusively asynchronous resolver.</remarks>
         [Obsolete("CachedResolver now works best with asynchronous resolvers. Use the AsyncSource property instead.")]
-        public IResourceResolver Source { get; }
+        public IResourceResolver Source { get; private set; }
 
         public IAsyncResourceResolver AsyncSource { get; }
 
         /// <summary>Gets the default expiration time of a cache entry.</summary>
         public int CacheDuration { get; }
 
+        /// <inheritdoc cref="ResolveByUriAsync(string)"/>
         [Obsolete("CachedResolver now works best with asynchronous resolvers. Use ResolveByUriAsync() instead.")]
         public Resource ResolveByUri(string url) => TaskHelper.Await(() => ResolveByUriAsync(url));
       
@@ -73,6 +76,7 @@ namespace Hl7.Fhir.Specification.Source
             return await _resourcesByUri.Get(url, CachedResolverLoadingStrategy.LoadOnDemand);
         }
 
+        /// <inheritdoc cref="ResolveByUriAsync(string, CachedResolverLoadingStrategy)"/>
         [Obsolete("CachedResolver now works best with asynchronous resolvers. Use ResolveByUriAsync() instead.")]
         public Resource ResolveByUri(string url, CachedResolverLoadingStrategy strategy) =>
                 TaskHelper.Await(() => ResolveByUriAsync(url, strategy));
@@ -88,6 +92,7 @@ namespace Hl7.Fhir.Specification.Source
             return await _resourcesByUri.Get(url, strategy);
         }
 
+        /// <inheritdoc cref="ResolveByCanonicalUriAsync(string)" />
         [Obsolete("CachedResolver now works best with asynchronous resolvers. Use ResolveByCanonicalUriAsync() instead.")]
         public Resource ResolveByCanonicalUri(string url) => TaskHelper.Await(() => ResolveByCanonicalUriAsync(url));
 
@@ -101,6 +106,7 @@ namespace Hl7.Fhir.Specification.Source
             return await _resourcesByCanonical.Get(url, CachedResolverLoadingStrategy.LoadOnDemand);
         }
 
+        /// <inheritdoc cref="ResolveByCanonicalUriAsync(string, CachedResolverLoadingStrategy)" />
         [Obsolete("CachedResolver now works best with asynchronous resolvers. Use ResolveByCanonicalUriAsync() instead.")]
         public Resource ResolveByCanonicalUri(string url, CachedResolverLoadingStrategy strategy) =>
                 TaskHelper.Await(() => ResolveByCanonicalUriAsync(url, strategy));

--- a/src/Hl7.Fhir.Support.Poco/Specification/Source/IResourceResolver.cs
+++ b/src/Hl7.Fhir.Support.Poco/Specification/Source/IResourceResolver.cs
@@ -1,0 +1,40 @@
+﻿/* 
+ * Copyright (c) 2016, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ * 
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/fhir-net-api/master/LICENSE
+ */
+
+using System;
+using System.Threading.Tasks;
+using Hl7.Fhir.Model;
+
+namespace Hl7.Fhir.Specification.Source
+{
+    /// <summary>Interface for resolving FHIR artifacts by (canonical) uri.</summary>
+    public interface IResourceResolver // open ended domain
+    {
+        /// <summary>Find a resource based on its relative or absolute uri.</summary>
+        /// <param name="uri">A resource uri.</param>
+        Resource ResolveByUri(string uri);
+
+
+        /// <summary>Find a (conformance) resource based on its canonical uri.</summary>
+        /// <param name="uri">The canonical url of a (conformance) resource.</param>
+        Resource ResolveByCanonicalUri(string uri); // IConformanceResource
+    }
+
+
+    public interface IAsyncResourceResolver
+    {
+        /// <summary>Find a resource based on its relative or absolute uri.</summary>
+        /// <param name="uri">A resource uri.</param>
+        Task<Resource> ResolveByUriAsync(string uri);
+
+
+        /// <summary>Find a (conformance) resource based on its canonical uri.</summary>
+        /// <param name="uri">The canonical url of a (conformance) resource.</param>
+        Task<Resource> ResolveByCanonicalUriAsync(string uri); // IConformanceResource
+    }
+}

--- a/src/Hl7.Fhir.Support.Poco/Specification/Source/IResourceResolver.cs
+++ b/src/Hl7.Fhir.Support.Poco/Specification/Source/IResourceResolver.cs
@@ -13,7 +13,9 @@ using Hl7.Fhir.Model;
 namespace Hl7.Fhir.Specification.Source
 {
     /// <summary>Interface for resolving FHIR artifacts by (canonical) uri.</summary>
-    public interface IResourceResolver // open ended domain
+#pragma warning disable CS0618 // Type or member is obsolete
+    public interface IResourceResolver : ISyncOrAsyncResourceResolver
+#pragma warning restore CS0618 // Type or member is obsolete
     {
         /// <summary>Find a resource based on its relative or absolute uri.</summary>
         /// <param name="uri">A resource uri.</param>
@@ -22,11 +24,13 @@ namespace Hl7.Fhir.Specification.Source
 
         /// <summary>Find a (conformance) resource based on its canonical uri.</summary>
         /// <param name="uri">The canonical url of a (conformance) resource.</param>
-        Resource ResolveByCanonicalUri(string uri); // IConformanceResource
+        Resource ResolveByCanonicalUri(string uri);
     }
 
 
-    public interface IAsyncResourceResolver
+#pragma warning disable CS0618 // Type or member is obsolete
+    public interface IAsyncResourceResolver : ISyncOrAsyncResourceResolver
+#pragma warning restore CS0618 // Type or member is obsolete
     {
         /// <summary>Find a resource based on its relative or absolute uri.</summary>
         /// <param name="uri">A resource uri.</param>
@@ -36,5 +40,14 @@ namespace Hl7.Fhir.Specification.Source
         /// <summary>Find a (conformance) resource based on its canonical uri.</summary>
         /// <param name="uri">The canonical url of a (conformance) resource.</param>
         Task<Resource> ResolveByCanonicalUriAsync(string uri); // IConformanceResource
+    }
+
+    /// <summary>
+    /// Empty marker interface to allow sync-backwards compatible code to support both sync and async resolvers.
+    /// </summary>
+    [Obsolete("This marker interface is used for backwards-compatibility only and should not be used in your code. " +
+        "Explicitly use IResourceResolver (also obsolete) or preferably IAsyncResourceResolver instead.")]
+    public interface ISyncOrAsyncResourceResolver
+    {
     }
 }

--- a/src/Hl7.Fhir.Support.Poco/Specification/Source/MultiResolver.cs
+++ b/src/Hl7.Fhir.Support.Poco/Specification/Source/MultiResolver.cs
@@ -58,16 +58,21 @@ namespace Hl7.Fhir.Specification.Source
         /// <summary>
         /// Return all child resolvers that support synchronous resolution.
         /// </summary>
+        /// <remarks>The collections returned by the <see cref="Sources"/> and <see cref="AsyncSources" /> properties are 
+        /// not necessarily disjunct.</remarks>
         public IList<IResourceResolver> Sources => _sources.OfType<IResourceResolver>().ToList();
 
         /// <summary>
         /// Return all child resolvers that support asynchronous resolution.
         /// </summary>
+        /// <remarks>The collections returned by the <see cref="AsyncSources"/> and <see cref="Sources" /> properties are 
+        /// not necessarily disjunct.</remarks>
         public IList<IAsyncResourceResolver> AsyncSources => _sources.OfType<IAsyncResourceResolver>().ToList();
 
         private IEnumerable<IAsyncResourceResolver> allSourcesAsAsync() => _sources.Select(src => src.AsAsync());
 
 
+        [Obsolete("MultiResolver now works best with asynchronous resolvers. Use ResolveByUriAsync() instead.")]
         public Resource ResolveByUri(string uri) => TaskHelper.Await(() => ResolveByUriAsync(uri));
 
         public async Task<Resource> ResolveByUriAsync(string uri)
@@ -92,7 +97,9 @@ namespace Hl7.Fhir.Specification.Source
             return null;
         }
 
+        [Obsolete("MultiResolver now works best with asynchronous resolvers. Use ResolveByCanonicalUriAsync() instead.")]
         public Resource ResolveByCanonicalUri(string uri) => TaskHelper.Await(() => ResolveByCanonicalUriAsync(uri));
+
         public async Task<Resource> ResolveByCanonicalUriAsync(string uri)
         {
             if (uri == null) throw Error.ArgumentNull(nameof(uri));

--- a/src/Hl7.Fhir.Support.Poco/Specification/Source/MultiResolver.cs
+++ b/src/Hl7.Fhir.Support.Poco/Specification/Source/MultiResolver.cs
@@ -1,0 +1,124 @@
+﻿/* 
+ * Copyright (c) 2016, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ * 
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://github.com/FirelyTeam/fhir-net-api/blob/master/LICENSE
+ */
+
+using System;
+using System.Collections.Generic;
+using Hl7.Fhir.Model;
+using System.Linq;
+using Hl7.Fhir.Utility;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace Hl7.Fhir.Specification.Source
+{
+    /// <summary>
+    /// Reads FHIR artifacts (Profiles, ValueSets, ...) from a list of other IArtifactSources
+    /// </summary>
+    [DebuggerDisplay(@"\{{DebuggerDisplay,nq}}")]
+    public class MultiResolver : IResourceResolver, IAsyncResourceResolver
+    {
+#pragma warning disable CS0618 // Type or member is obsolete
+        private readonly List<ISyncOrAsyncResourceResolver> _sources = new List<ISyncOrAsyncResourceResolver>();
+
+        public MultiResolver(IEnumerable<ISyncOrAsyncResourceResolver> sources)
+        {
+            if (sources == null) throw Error.ArgumentNull(nameof(sources));
+
+            _sources.AddRange(sources);
+        }
+
+        public MultiResolver(params ISyncOrAsyncResourceResolver[] sources) : this((IEnumerable<ISyncOrAsyncResourceResolver>)sources) { }
+
+        public void AddSource(ISyncOrAsyncResourceResolver source)
+        {
+            _sources.Add(source);
+        }
+
+        public void RemoveSource(ISyncOrAsyncResourceResolver source)
+        {
+            _sources.Remove(source);
+        }
+
+        public void Push(ISyncOrAsyncResourceResolver source)
+        {
+            _sources.Insert(0, source);
+        }
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        public void Pop()
+        {
+            if (_sources.Any()) _sources.RemoveAt(0);
+        }
+
+        /// <summary>
+        /// Return all child resolvers that support synchronous resolution.
+        /// </summary>
+        public IList<IResourceResolver> Sources => _sources.OfType<IResourceResolver>().ToList();
+
+        /// <summary>
+        /// Return all child resolvers that support asynchronous resolution.
+        /// </summary>
+        public IList<IAsyncResourceResolver> AsyncSources => _sources.OfType<IAsyncResourceResolver>().ToList();
+
+        private IEnumerable<IAsyncResourceResolver> allSourcesAsAsync() => _sources.Select(src => src.AsAsync());
+
+
+        public Resource ResolveByUri(string uri) => TaskHelper.Await(() => ResolveByUriAsync(uri));
+
+        public async Task<Resource> ResolveByUriAsync(string uri)
+        {
+            if (uri == null) throw Error.ArgumentNull(nameof(uri));
+
+            foreach (IAsyncResourceResolver source in allSourcesAsAsync())
+            {
+                try
+                {
+                    var result = await source.ResolveByUriAsync(uri);
+
+                    if (result != null) return result;
+                }
+                catch(NotImplementedException)
+                {
+                    // Don't do anything, just try the next IArtifactSource
+                }
+            }
+
+            // None of the IArtifactSources succeeded in returning a result
+            return null;
+        }
+
+        public Resource ResolveByCanonicalUri(string uri) => TaskHelper.Await(() => ResolveByCanonicalUriAsync(uri));
+        public async Task<Resource> ResolveByCanonicalUriAsync(string uri)
+        {
+            if (uri == null) throw Error.ArgumentNull(nameof(uri));
+
+            foreach (var source in allSourcesAsAsync())
+            {
+                try
+                {
+                    var result = await source.ResolveByCanonicalUriAsync(uri);
+
+                    if (result != null) return result;
+                }
+                catch (NotImplementedException)
+                {
+                    // Don't do anything, just try the next IArtifactSource
+                }
+            }
+
+            // None of the IArtifactSources succeeded in returning a result
+            return null;
+        }
+
+        // Allow derived classes to override
+        // http://blogs.msdn.com/b/jaredpar/archive/2011/03/18/debuggerdisplay-attribute-best-practices.aspx
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        internal protected virtual string DebuggerDisplay
+            => $"{GetType().Name} for {_sources.Count} sources: {string.Join(" | ", _sources.Select(s => s.DebuggerDisplayString()))}";
+    }
+}

--- a/src/Hl7.Fhir.Support.Poco/Specification/Source/SyncToAsyncResolver.cs
+++ b/src/Hl7.Fhir.Support.Poco/Specification/Source/SyncToAsyncResolver.cs
@@ -26,10 +26,9 @@ namespace Hl7.Fhir.Specification.Source
             var result = SyncResolver.ResolveByUri(uri);
 
 #if NET40
-            //return TaskEx.FromResult(result);
-            return null;
+            return TaskEx.FromResult(result);
 #else
-            return System.Threading.Tasks.Task.FromResult(result);
+            return Task.FromResult(result);
 #endif
         }
 
@@ -37,10 +36,9 @@ namespace Hl7.Fhir.Specification.Source
         {
             var result = SyncResolver.ResolveByCanonicalUri(uri);
 #if NET40
-            //return TaskEx.FromResult(result);
-            return null;
+            return TaskEx.FromResult(result);
 #else
-            return System.Threading.Tasks.Task.FromResult(result);
+            return Task.FromResult(result);
 #endif
         }
     }

--- a/src/Hl7.Fhir.Support.Poco/Specification/Source/SyncToAsyncResolver.cs
+++ b/src/Hl7.Fhir.Support.Poco/Specification/Source/SyncToAsyncResolver.cs
@@ -1,0 +1,61 @@
+﻿/* 
+ * Copyright (c) 2020, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ * 
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://github.com/FirelyTeam/fhir-net-api/blob/master/LICENSE
+ */
+
+using System;
+using Hl7.Fhir.Model;
+using System.Threading.Tasks;
+
+namespace Hl7.Fhir.Specification.Source
+{
+    /// <summary>
+    /// Implements <see cref="IAsyncResourceResolver" /> on top of an <see cref="IResourceResolver" />
+    /// </summary>
+    public class SyncToAsyncResolver : IAsyncResourceResolver
+    {
+        public IResourceResolver SyncResolver { get; private set; }
+
+        public SyncToAsyncResolver(IResourceResolver sync) => SyncResolver = sync ?? throw new ArgumentNullException(nameof(sync));
+
+        public Task<Resource> ResolveByUriAsync(string uri)
+        {
+            var result = SyncResolver.ResolveByUri(uri);
+
+#if NET40
+            //return TaskEx.FromResult(result);
+            return null;
+#else
+            return System.Threading.Tasks.Task.FromResult(result);
+#endif
+        }
+
+        public Task<Resource> ResolveByCanonicalUriAsync(string uri)
+        {
+            var result = SyncResolver.ResolveByCanonicalUri(uri);
+#if NET40
+            //return TaskEx.FromResult(result);
+            return null;
+#else
+            return System.Threading.Tasks.Task.FromResult(result);
+#endif
+        }
+    }
+
+    public static class SyncToAsyncResolverExtensions
+    { 
+        /// <summary>
+        /// Converts a (possibly non-async) resource resolver to an async one.
+        /// </summary>
+        /// <param name="source"></param>
+        /// <returns></returns>
+        /// <remarks>Note that this async method will block on the possibly synchronous source. This method
+        /// is meant for temporary backwards-compatiblity reasons only.</remarks>
+        public static IAsyncResourceResolver ToAsync(this IResourceResolver source) =>
+            source is IAsyncResourceResolver ar ? ar : new SyncToAsyncResolver(source);
+    }
+
+}

--- a/src/Hl7.Fhir.Support.Poco/Specification/Source/SyncToAsyncResolver.cs
+++ b/src/Hl7.Fhir.Support.Poco/Specification/Source/SyncToAsyncResolver.cs
@@ -44,7 +44,7 @@ namespace Hl7.Fhir.Specification.Source
     }
 
     public static class SyncToAsyncResolverExtensions
-    { 
+    {
         /// <summary>
         /// Converts a (possibly non-async) resource resolver to an async one.
         /// </summary>
@@ -52,8 +52,13 @@ namespace Hl7.Fhir.Specification.Source
         /// <returns></returns>
         /// <remarks>Note that this async method will block on the possibly synchronous source. This method
         /// is meant for temporary backwards-compatiblity reasons only.</remarks>
-        public static IAsyncResourceResolver ToAsync(this IResourceResolver source) =>
-            source is IAsyncResourceResolver ar ? ar : new SyncToAsyncResolver(source);
+#pragma warning disable CS0618 // Type or member is obsolete
+        public static IAsyncResourceResolver AsAsync(this ISyncOrAsyncResourceResolver source) =>
+#pragma warning restore CS0618 // Type or member is obsolete
+            source is IAsyncResourceResolver ar ? ar
+                : source is IResourceResolver sr ? new SyncToAsyncResolver(sr)
+                    : throw new ArgumentException($"Argument {nameof(source)} is neither a {nameof(IResourceResolver)} nor " +
+                        $"a {nameof(IAsyncResourceResolver)}");
     }
 
 }

--- a/src/Hl7.Fhir.Support.Tests/Hl7.Fhir.Support.Tests.csproj
+++ b/src/Hl7.Fhir.Support.Tests/Hl7.Fhir.Support.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net45;net40</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net45</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\fhir-net-common.props" />
@@ -39,11 +39,5 @@
 
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
-    <PackageReference Include="System.ComponentModel.Annotations">
-      <Version>4.7.0</Version>
-    </PackageReference>
   </ItemGroup>
 </Project>

--- a/src/Hl7.Fhir.Support.Tests/Specification/AsyncSources.cs
+++ b/src/Hl7.Fhir.Support.Tests/Specification/AsyncSources.cs
@@ -1,0 +1,196 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
+using Hl7.Fhir.Utility;
+using Hl7.Fhir.Specification.Source;
+using Hl7.Fhir.Model;
+using System.Threading.Tasks;
+
+namespace Hl7.Fhir.Support.Utility.Tests
+{
+    [TestClass]
+    public class AsyncSourcesTests
+    {
+        [TestMethod]
+        public async Task TestAdaptedSyncSource()
+        {
+            var adaptee = new SyncResolver();
+            var adapted = adaptee.AsAsync();
+
+            _ = await adapted.ResolveByUriAsync("");
+            _ = await adapted.ResolveByCanonicalUriAsync("");
+            _ = await adapted.ResolveByCanonicalUriAsync("");
+
+            Assert.AreEqual(2, adaptee.ByCanonical);
+            Assert.AreEqual(1, adaptee.ByUri);
+
+            // Now call the async adapted sync resolver synchronously ;-)
+            TaskHelper.Await(() => adapted.ResolveByUriAsync(""));
+            Assert.AreEqual(2, adaptee.ByUri);
+        }
+
+        [TestMethod]
+        public async Task TestAsyncSyncMultiResolver()
+        {
+            var (sr, ar, sar) = (new SyncResolver(), new AsyncResolver(), new SyncAsyncResolver());
+            var multi = new MultiResolver(sr,ar,sar);
+
+            // calling *any* kind of resolve will involve all child resolvers, since they all return null.
+            _ = await multi.ResolveByUriAsync("");
+#pragma warning disable CS0618 // Type or member is obsolete
+            _ = multi.ResolveByCanonicalUri("");
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            Assert.AreEqual(1, sr.ByUri);
+            Assert.AreEqual(1, sr.ByCanonical);
+
+            Assert.AreEqual(1, ar.ByUriAsync);
+            Assert.AreEqual(1, ar.ByCanonicalAsync);
+
+            Assert.AreEqual(0, sar.ByUri);  // multi will always prefer the async
+            Assert.AreEqual(0, sar.ByCanonical); // multi will always prefer the async
+            Assert.AreEqual(1, sar.ByUriAsync);
+            Assert.AreEqual(1, sar.ByCanonicalAsync);
+        }
+
+
+        [TestMethod]
+        public async Task TestCacheOnSyncAsync()
+        {
+            var sync = new SyncResolver(new AResource { Data = 1 });
+            var c1 = new CachedResolver(sync);
+            await test(c1);
+            Assert.AreEqual(1, sync.ByUri);
+            Assert.AreEqual(1, sync.ByCanonical);
+
+            var async = new AsyncResolver(new AResource { Data = 1 });
+            var c2 = new CachedResolver(async);
+            await test(c2);
+            Assert.AreEqual(1, async.ByUriAsync);
+            Assert.AreEqual(1, async.ByCanonicalAsync);
+
+            var sasync = new SyncAsyncResolver(new AResource { Data = 1 });
+            var c3 = new CachedResolver(sasync);
+            await test(c3);
+            Assert.AreEqual(0, sasync.ByUri); // cache will always prefer the async
+            Assert.AreEqual(0, sasync.ByCanonical); // cache will always prefer the async
+            Assert.AreEqual(1, sasync.ByUriAsync);
+            Assert.AreEqual(1, sasync.ByCanonicalAsync);
+
+            async Task test(CachedResolver r)
+            {
+#pragma warning disable CS0618 // Type or member is obsolete
+                var result = r.ResolveByUri("t") as AResource;
+#pragma warning restore CS0618 // Type or member is obsolete
+                Assert.AreEqual(1, result.Data);
+
+                result = await r.ResolveByCanonicalUriAsync("t") as AResource;
+                Assert.AreEqual(1, result.Data);
+            }
+        }
+      
+    }
+
+
+    internal class SyncResolver : IResourceResolver
+    {
+        public int ByCanonical;
+        public int ByUri;
+        public Resource Data;
+
+        public SyncResolver() { }
+
+        public SyncResolver(Resource data)
+        {
+            Data = data;
+        }
+
+        public Resource ResolveByCanonicalUri(string uri)
+        {
+            ByCanonical += 1;
+            return Data;
+        }
+
+        public Resource ResolveByUri(string uri)
+        {
+            ByUri += 1;
+            return Data;
+        }
+    }
+
+    internal class AsyncResolver : IAsyncResourceResolver
+    {
+        public int ByCanonicalAsync;
+        public int ByUriAsync;
+        public Resource Data;
+
+        public AsyncResolver() { }
+
+        public AsyncResolver(Resource data)
+        {
+            Data = data;
+        }
+
+
+        public Task<Resource> ResolveByCanonicalUriAsync(string uri)
+        {
+            ByCanonicalAsync += 1;
+            return Task.FromResult(Data);
+        }
+
+        public Task<Resource> ResolveByUriAsync(string uri)
+        {
+            ByUriAsync += 1;
+            return Task.FromResult(Data);
+        }
+    }
+
+
+    internal class SyncAsyncResolver : IResourceResolver, IAsyncResourceResolver
+    {
+        public int ByCanonical;
+        public int ByUri;
+        public int ByCanonicalAsync;
+        public int ByUriAsync;
+
+        public Resource Data;
+
+        public SyncAsyncResolver() { }
+
+        public SyncAsyncResolver(Resource data)
+        {
+            Data = data;
+        }
+
+        public Resource ResolveByCanonicalUri(string uri)
+        {
+            ByCanonical += 1;
+            return Data;
+        }
+
+        public Resource ResolveByUri(string uri)
+        {
+            ByUri += 1;
+            return Data;
+        }
+
+        public Task<Resource> ResolveByCanonicalUriAsync(string uri)
+        {
+            ByCanonicalAsync += 1;
+            return Task.FromResult(Data);
+        }
+
+        public Task<Resource> ResolveByUriAsync(string uri)
+        {
+            ByUriAsync += 1;
+            return Task.FromResult(Data);
+        }
+    }
+
+    internal class AResource : Resource
+    {
+        public int Data;
+
+        public override IDeepCopyable DeepCopy() => throw new NotImplementedException();
+    }
+}

--- a/src/Hl7.Fhir.Support.Tests/Utility/DebugDisplayTest.cs
+++ b/src/Hl7.Fhir.Support.Tests/Utility/DebugDisplayTest.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
+using Hl7.Fhir.Utility;
+
+namespace Hl7.Fhir.Support.Utility.Tests
+{
+    [TestClass]
+    public class DebugDisplayTests
+    {
+        [TestMethod]
+        public void GetDebugDisplay()
+        {
+            var testee = new ClassWithDebugDisplay();
+            Assert.AreEqual("You found it",testee.DebuggerDisplayString());
+
+            var testee2 = new ClassWithDebugDisplay2();
+            Assert.AreEqual("You found it", testee2.DebuggerDisplayString());
+
+            var testee3 = new ClassWithDebugDisplay3();
+            Assert.AreEqual("You found me too", testee3.DebuggerDisplayString());
+        }
+    }
+
+
+    internal class ClassWithDebugDisplay
+    {
+        internal protected virtual string DebuggerDisplay => "You found it";
+    }
+
+    internal class ClassWithDebugDisplay2 : ClassWithDebugDisplay
+    {
+
+    }
+
+    internal class ClassWithDebugDisplay3 : ClassWithDebugDisplay
+    {
+        protected internal override string DebuggerDisplay => "You found me too";
+    }
+
+}

--- a/src/Hl7.Fhir.Support/Hl7.Fhir.Support.csproj
+++ b/src/Hl7.Fhir.Support/Hl7.Fhir.Support.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net40;net45;netstandard1.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.1;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\fhir-net-common.props" />

--- a/src/Hl7.Fhir.Support/Utility/DebuggerDisplayExtensions.cs
+++ b/src/Hl7.Fhir.Support/Utility/DebuggerDisplayExtensions.cs
@@ -1,0 +1,22 @@
+﻿/* 
+ * Copyright (c) 2020, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ * 
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/fhir-net-api/master/LICENSE
+ */
+
+namespace Hl7.Fhir.Utility
+{
+    public static class DebuggerDisplayExtensions
+    {
+        public const string DEBUGGER_DISPLAY_PROP_NAME = "DebuggerDisplay";
+        public static string DebuggerDisplayString(this object target)
+        {
+            var debuggerDisplay = ReflectionHelper.FindProperty(target.GetType(), DEBUGGER_DISPLAY_PROP_NAME);
+            if (debuggerDisplay == null) return null;
+
+            return debuggerDisplay.GetValue(target, null) as string;
+        }
+    }
+}

--- a/src/Hl7.Fhir.Support/Utility/DebuggerDisplayExtensions.cs
+++ b/src/Hl7.Fhir.Support/Utility/DebuggerDisplayExtensions.cs
@@ -14,7 +14,7 @@ namespace Hl7.Fhir.Utility
         public static string DebuggerDisplayString(this object target)
         {
             var debuggerDisplay = ReflectionHelper.FindProperty(target.GetType(), DEBUGGER_DISPLAY_PROP_NAME);
-            if (debuggerDisplay == null) return null;
+            if (debuggerDisplay is null) return null;
 
             return debuggerDisplay.GetValue(target, null) as string;
         }

--- a/src/Hl7.Fhir.Support/Utility/ReflectionHelper.cs
+++ b/src/Hl7.Fhir.Support/Utility/ReflectionHelper.cs
@@ -230,6 +230,21 @@ namespace Hl7.Fhir.Utility
         }
 
 
+        public static PropertyInfo FindProperty(Type t, string name)
+        {
+#if NETSTANDARD1_1
+            return t.GetRuntimeProperties().FirstOrDefault(rtp => rtp.Name == name);
+#else
+            return t.GetProperty(name,BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+#endif
+
+        }
+
+        /// <summary>
+        /// Returns all public, non-static properties for the given type.
+        /// </summary>
+        /// <param name="t"></param>
+        /// <returns></returns>
         public static IEnumerable<PropertyInfo> FindPublicProperties(Type t)
         {
             if (t == null) throw Error.ArgumentNull("t");

--- a/src/Hl7.Fhir.Support/Utility/SyncToAsyncExtensions.cs
+++ b/src/Hl7.Fhir.Support/Utility/SyncToAsyncExtensions.cs
@@ -7,6 +7,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Hl7.Fhir.Utility
@@ -22,13 +23,21 @@ namespace Hl7.Fhir.Utility
 #endif
         }
 
-        public static void Await<T>(Func<Task> asyncFunc)
+        public static void Await(Func<Task> asyncFunc)
         {
 #if NET40
             TaskEx.Run(asyncFunc).Wait();
 #else
             Task.Run(asyncFunc).Wait();
 #endif
+        }
+
+        public static async Task<bool> AnyAsync<TSource>(this IEnumerable<TSource> source, Func<TSource, Task<bool>> predicate)
+        {
+            foreach (var elem in source)
+                if (await predicate(elem)) return true;
+
+            return false;
         }
     }
 }

--- a/src/Hl7.Fhir.Support/Utility/SyncToAsyncExtensions.cs
+++ b/src/Hl7.Fhir.Support/Utility/SyncToAsyncExtensions.cs
@@ -17,18 +17,20 @@ namespace Hl7.Fhir.Utility
         public static T Await<T>(Func<Task<T>> asyncFunc)
         {
 #if NET40
-            return TaskEx.Run(asyncFunc).Result;
+            return TaskEx.Run(asyncFunc).GetAwaiter().GetResult();
 #else
-            return Task.Run(asyncFunc).Result;
+            // Call GetAwaiter() rather then .Result to unwrap the AggregateException
+            return Task.Run(asyncFunc).GetAwaiter().GetResult();
 #endif
         }
 
         public static void Await(Func<Task> asyncFunc)
         {
 #if NET40
-            TaskEx.Run(asyncFunc).Wait();
+            TaskEx.Run(asyncFunc).GetAwaiter().GetResult();
 #else
-            Task.Run(asyncFunc).Wait();
+            // Call GetAwaiter() rather then .Result to unwrap the AggregateException
+            Task.Run(asyncFunc).GetAwaiter().GetResult();
 #endif
         }
 

--- a/src/Hl7.Fhir.Support/Utility/SyncToAsyncExtensions.cs
+++ b/src/Hl7.Fhir.Support/Utility/SyncToAsyncExtensions.cs
@@ -1,0 +1,37 @@
+﻿/* 
+ * Copyright (c) 2020, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ * 
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/fhir-net-api/master/LICENSE
+ */
+
+using System;
+using System.Threading.Tasks;
+
+namespace Hl7.Fhir.Utility
+{
+    public static class TaskHelper
+    {
+        public static T Await<T>(Func<Task<T>> asyncFunc)
+        {
+#if NET40
+            // return TaskEx.Run(asyncFunc).Result;
+            return default;
+#else
+            return Task.Run(asyncFunc).Result;
+#endif
+        }
+
+        public static void Await<T>(Func<Task> asyncFunc)
+        {
+#if NET40
+           // TaskEx.Run(asyncFunc).Wait();
+#else
+            Task.Run(asyncFunc).Wait();
+#endif
+        }
+
+    }
+
+}

--- a/src/Hl7.Fhir.Support/Utility/SyncToAsyncExtensions.cs
+++ b/src/Hl7.Fhir.Support/Utility/SyncToAsyncExtensions.cs
@@ -16,8 +16,7 @@ namespace Hl7.Fhir.Utility
         public static T Await<T>(Func<Task<T>> asyncFunc)
         {
 #if NET40
-            // return TaskEx.Run(asyncFunc).Result;
-            return default;
+            return TaskEx.Run(asyncFunc).Result;
 #else
             return Task.Run(asyncFunc).Result;
 #endif
@@ -26,7 +25,7 @@ namespace Hl7.Fhir.Utility
         public static void Await<T>(Func<Task> asyncFunc)
         {
 #if NET40
-           // TaskEx.Run(asyncFunc).Wait();
+            TaskEx.Run(asyncFunc).Wait();
 #else
             Task.Run(asyncFunc).Wait();
 #endif

--- a/src/Hl7.Fhir.Support/Utility/SyncToAsyncExtensions.cs
+++ b/src/Hl7.Fhir.Support/Utility/SyncToAsyncExtensions.cs
@@ -30,7 +30,5 @@ namespace Hl7.Fhir.Utility
             Task.Run(asyncFunc).Wait();
 #endif
         }
-
     }
-
 }

--- a/src/Hl7.FhirPath/Hl7.FhirPath.csproj
+++ b/src/Hl7.FhirPath/Hl7.FhirPath.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net45;net40;netstandard1.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.1;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\fhir-net-common.props" />


### PR DESCRIPTION
Add infrastructure to create asynchronous resolvers, and update the snapshot generator to use them.

Note: API still has many places where it uses the now-obsolete synchronous calls.