### PR TITLE
fix: 1140 casting did not account for empty primitives

### DIFF
--- a/src/Hl7.FhirPath.Tests/Tests/BasicFunctionTests.cs
+++ b/src/Hl7.FhirPath.Tests/Tests/BasicFunctionTests.cs
@@ -1,0 +1,55 @@
+﻿/* 
+ * Copyright (c) 2015, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ * 
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/fhir-net-api/master/LICENSE
+ */
+
+// To introduce the DSTU2 FHIR specification
+//extern alias dstu2;
+
+using Hl7.Fhir.ElementModel;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+
+namespace Hl7.FhirPath.Tests
+{
+    [TestClass]
+    public class BasicFunctionsTest
+    {     
+        [TestMethod]
+        public void IsDistinctWorksOnEmptyCollections()
+        {
+            ITypedElement dummy = ElementNode.ForPrimitive(true);
+
+            Assert.IsTrue(dummy.IsBoolean("{}.isDistinct()", true));
+            Assert.IsTrue(dummy.IsBoolean("(2).isDistinct()", true));
+        }
+
+        [TestMethod]
+        public void StringConcatenationAndEmpty()
+        {
+            ITypedElement dummy = ElementNode.ForPrimitive(true);
+
+            Assert.AreEqual("ABCDEF", dummy.Scalar("'ABC' + '' + 'DEF'"));
+            Assert.AreEqual("DEF", dummy.Scalar("'' + 'DEF'"));
+            Assert.AreEqual("DEF", dummy.Scalar("'DEF' + ''"));
+
+            Assert.IsNull(dummy.Scalar("{} + 'DEF'"));
+            Assert.IsNull(dummy.Scalar("'ABC' + {} + 'DEF'"));
+            Assert.IsNull(dummy.Scalar("'ABC' + {}"));
+
+            Assert.AreEqual("ABCDEF", dummy.Scalar("'ABC' & '' & 'DEF'"));
+            Assert.AreEqual("DEF", dummy.Scalar("'' & 'DEF'"));
+            Assert.AreEqual("DEF", dummy.Scalar("'DEF' & ''"));
+
+            Assert.AreEqual("DEF", dummy.Scalar("{} & 'DEF'"));
+            Assert.AreEqual("ABCDEF", dummy.Scalar("'ABC' & {} & 'DEF'"));
+            Assert.AreEqual("ABC", dummy.Scalar("'ABC' & {}"));
+
+            Assert.IsNull(dummy.Scalar("'ABC' & {} & 'DEF' + {}"));
+        }
+    }
+        
+}

--- a/src/Hl7.FhirPath/FhirPath/Expressions/Typecasts.cs
+++ b/src/Hl7.FhirPath/FhirPath/Expressions/Typecasts.cs
@@ -1,4 +1,4 @@
-﻿/* 
+/* 
  * Copyright (c) 2015, Firely (info@fire.ly) and contributors
  * See the file CONTRIBUTORS for details.
  * 
@@ -89,9 +89,8 @@ namespace Hl7.FhirPath.Expressions
 
             if (to.CanBeTreatedAsType(typeof(IEnumerable<ITypedElement>))) return instance;
 
-            if (instance is IEnumerable<ITypedElement>)
+            if (instance is IEnumerable<ITypedElement> list)
             {
-                var list = (IEnumerable<ITypedElement>)instance;
                 if (!list.Any()) return null;
                 if (list.Count() == 1)
                     instance = list.Single();
@@ -99,14 +98,9 @@ namespace Hl7.FhirPath.Expressions
 
             if (to.CanBeTreatedAsType(typeof(ITypedElement))) return instance;
 
-            if (instance is ITypedElement)
-            {
-                var element = (ITypedElement)instance;
-
-                if (element.Value != null)
-                    instance = element.Value;
-            }
-
+            if (instance is ITypedElement element && to != typeof(object))
+                return element.Value;
+            
             return instance;
         }
 


### PR DESCRIPTION
This fixes the FhirPath error on the STU3 eld13 expression.
