### PR TITLE
Add a "split" string manipulation function to FHIRPath

### DIFF
--- a/src/Hl7.FhirPath.Tests/Tests/BasicFunctionTests.cs
+++ b/src/Hl7.FhirPath.Tests/Tests/BasicFunctionTests.cs
@@ -12,6 +12,7 @@
 using Hl7.Fhir.ElementModel;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Hl7.FhirPath.Tests
 {
@@ -49,6 +50,29 @@ namespace Hl7.FhirPath.Tests
             Assert.AreEqual("ABC", dummy.Scalar("'ABC' & {}"));
 
             Assert.IsNull(dummy.Scalar("'ABC' & {} & 'DEF' + {}"));
+        }
+
+        [TestMethod]
+        public void TestStringSplit()
+        {
+            ITypedElement dummy = ElementNode.ForPrimitive("a,b,c,d");
+            var result = dummy.Select("split(',')");
+            Assert.IsNotNull(result);
+            CollectionAssert.AreEqual(new[] { "a", "b", "c", "d" }, result.Select(r => r.Value.ToString()).ToArray());
+
+            dummy = ElementNode.ForPrimitive("a,,b,c,d"); // Empty element should be removed
+            result = dummy.Select("split(',')");
+            Assert.IsNotNull(result);
+            CollectionAssert.AreEqual(new[] { "a", "b", "c", "d" }, result.Select(r => r.Value.ToString()).ToArray());
+
+            dummy = ElementNode.ForPrimitive("");
+            result = dummy.Select("split(',')");
+            Assert.IsNotNull(result);
+
+            dummy = ElementNode.ForPrimitive("[stop]ONE[stop][stop]TWO[stop][stop][stop]THREE[stop][stop]");
+            result = dummy.Select("split('[stop]')");
+            Assert.IsNotNull(result);
+            CollectionAssert.AreEqual(new[] { "ONE", "TWO", "THREE" }, result.Select(r => r.Value.ToString()).ToArray());
         }
     }
         

--- a/src/Hl7.FhirPath/FhirPath/Expressions/SymbolTableInit.cs
+++ b/src/Hl7.FhirPath/FhirPath/Expressions/SymbolTableInit.cs
@@ -126,6 +126,7 @@ namespace Hl7.FhirPath.Expressions
             t.Add("replaceMatches", (string f, string regex, string subst) => Regex.Replace(f, regex, subst), doNullProp: true);
             t.Add("replace", (string f, string regex, string subst) => f.FpReplace(regex, subst), doNullProp: true);
             t.Add("length", (string f) => f.Length, doNullProp: true);
+            t.Add("split", (string f, string seperator) => f.FpSplit(seperator), doNullProp: true);
 
             // The next two functions existed pre-normative, so we have kept them.
             t.Add("is", (ITypedElement f, string name) => f.Is(name), doNullProp: true);

--- a/src/Hl7.FhirPath/FhirPath/Functions/StringOperators.cs
+++ b/src/Hl7.FhirPath/FhirPath/Functions/StringOperators.cs
@@ -45,5 +45,11 @@ namespace Hl7.FhirPath.Functions
             else
                 return me.Replace(find, replace);
         }
+
+        public static IEnumerable<ITypedElement> FpSplit(this string me, string seperator)
+        {
+            var results = me.Split(new[] { seperator }, StringSplitOptions.RemoveEmptyEntries);
+            return results.Select(s => ElementNode.ForPrimitive(s));
+        }
     }
 }


### PR DESCRIPTION
Solves [Issue #1334](https://github.com/FirelyTeam/fhir-net-api/issues/1334) by adding a new FHIRPath a split function to FHIRPath: split(separator : string) -> IEnumerable<ITypedElement>