### PR TITLE
rewrite: remove useless Primitive<T>

### DIFF
--- a/src/Hl7.Fhir.Support.Poco/Model/Base64Binary.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Base64Binary.cs
@@ -45,7 +45,7 @@ namespace Hl7.Fhir.Model
     [System.Diagnostics.DebuggerDisplay(@"\{Value={Value}}")]
     [FhirType("base64Binary")]
     [DataContract]
-    public class Base64Binary : PrimitiveType<byte[]>, IValue<byte[]>
+    public class Base64Binary : PrimitiveType, IValue<byte[]>
     {
         public override string TypeName { get { return "base64Binary"; } }
 

--- a/src/Hl7.Fhir.Support.Poco/Model/Canonical.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Canonical.cs
@@ -44,7 +44,7 @@ namespace Hl7.Fhir.Model
     [System.Diagnostics.DebuggerDisplay(@"\{{Value}}")] // http://blogs.msdn.com/b/jaredpar/archive/2011/03/18/debuggerdisplay-attribute-best-practices.aspx
     [FhirType("canonical")]
     [DataContract]
-    public class Canonical : PrimitiveType<string>, IStringValue
+    public class Canonical : PrimitiveType, IStringValue
     {
         public override string TypeName { get { return "canonical"; } }
         

--- a/src/Hl7.Fhir.Support.Poco/Model/Code.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Code.cs
@@ -46,7 +46,7 @@ namespace Hl7.Fhir.Model
     [System.Diagnostics.DebuggerDisplay(@"\{Value={Value}}")]
     [FhirType("code")]
     [DataContract]
-    public class Code : PrimitiveType<string>, IStringValue
+    public class Code : PrimitiveType, IStringValue
     {
         public override string TypeName { get { return "code"; } }
         

--- a/src/Hl7.Fhir.Support.Poco/Model/CodeOfT.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/CodeOfT.cs
@@ -44,7 +44,7 @@ namespace Hl7.Fhir.Model
     [FhirType("codeOfT")]
     [DataContract]
     [System.Diagnostics.DebuggerDisplay(@"\{Value={Value}}")]
-    public class Code<T> : PrimitiveType<T>, INullableValue<T>, ISystemAndCode where T : struct
+    public class Code<T> : PrimitiveType, INullableValue<T>, ISystemAndCode where T : struct
     {
         static Code()
         {

--- a/src/Hl7.Fhir.Support.Poco/Model/Date.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Date.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
     [System.Diagnostics.DebuggerDisplay(@"\{Value={Value}}")]
     [FhirType("date")]
     [DataContract]
-    public partial class Date : PrimitiveType<string>, IStringValue
+    public partial class Date : PrimitiveType, IStringValue
     {
         public override string TypeName { get { return "date"; } }
         

--- a/src/Hl7.Fhir.Support.Poco/Model/FhirBoolean.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/FhirBoolean.cs
@@ -43,7 +43,7 @@ namespace Hl7.Fhir.Model
     [FhirType("boolean")]
     [DataContract]
     [System.Diagnostics.DebuggerDisplay(@"\{Value={Value}}")]
-    public class FhirBoolean : PrimitiveType<bool?>, INullableValue<bool>
+    public class FhirBoolean : PrimitiveType, INullableValue<bool>
     {
         public override string TypeName { get { return "boolean"; } }
         

--- a/src/Hl7.Fhir.Support.Poco/Model/FhirDateTime.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/FhirDateTime.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
     [System.Diagnostics.DebuggerDisplay(@"\{Value={Value}}")]
     [FhirType("dateTime")]
     [DataContract]
-    public partial class FhirDateTime : PrimitiveType<string>, IStringValue
+    public partial class FhirDateTime : PrimitiveType, IStringValue
     {
         public const string FMT_FULL = "yyyy-MM-dd'T'HH:mm:ssK";
         public const string FMT_YEAR = "{0:D4}";

--- a/src/Hl7.Fhir.Support.Poco/Model/FhirDecimal.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/FhirDecimal.cs
@@ -46,7 +46,7 @@ namespace Hl7.Fhir.Model
     [System.Diagnostics.DebuggerDisplay(@"\{Value={Value}}")]
     [FhirType("decimal")]
     [DataContract]
-    public partial class FhirDecimal : Hl7.Fhir.Model.PrimitiveType<decimal?>, INullableValue<decimal>
+    public partial class FhirDecimal : PrimitiveType, INullableValue<decimal>
     {
         public override string TypeName { get { return "decimal"; } }
         

--- a/src/Hl7.Fhir.Support.Poco/Model/FhirString.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/FhirString.cs
@@ -44,7 +44,7 @@ namespace Hl7.Fhir.Model
     [System.Diagnostics.DebuggerDisplay(@"\{Value={Value}}")]
     [FhirType("string")]
     [DataContract]    
-    public class FhirString : PrimitiveType<string>, IStringValue
+    public class FhirString : PrimitiveType, IStringValue
     {
         public override string TypeName { get { return "string"; } }
         

--- a/src/Hl7.Fhir.Support.Poco/Model/FhirUri.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/FhirUri.cs
@@ -45,7 +45,7 @@ namespace Hl7.Fhir.Model
     [System.Diagnostics.DebuggerDisplay(@"\{Value={Value}}")]
     [FhirType("uri")]
     [DataContract]
-    public class FhirUri : PrimitiveType<string>, IStringValue
+    public class FhirUri : PrimitiveType, IStringValue
     {
         public override string TypeName { get { return "uri"; } }
         

--- a/src/Hl7.Fhir.Support.Poco/Model/FhirUrl.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/FhirUrl.cs
@@ -44,7 +44,7 @@ namespace Hl7.Fhir.Model
     [System.Diagnostics.DebuggerDisplay(@"\{{Value,nq}}")] // http://blogs.msdn.com/b/jaredpar/archive/2011/03/18/debuggerdisplay-attribute-best-practices.aspx
     [FhirType("url")]
     [DataContract]
-    public partial class FhirUrl : PrimitiveType<string>, IStringValue
+    public partial class FhirUrl : PrimitiveType, IStringValue
     {
         public override string TypeName { get { return "url"; } }
         

--- a/src/Hl7.Fhir.Support.Poco/Model/Id.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Id.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
     [System.Diagnostics.DebuggerDisplay(@"\{Value={Value}}")]
     [FhirType("id")]
     [DataContract]    
-    public class Id : PrimitiveType<string>, IStringValue
+    public class Id : PrimitiveType, IStringValue
     {
         public override string TypeName { get { return "id"; } }
         

--- a/src/Hl7.Fhir.Support.Poco/Model/Instant.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Instant.cs
@@ -45,7 +45,7 @@ namespace Hl7.Fhir.Model
     [System.Diagnostics.DebuggerDisplay(@"\{Value={Value}}")]
     [FhirType("instant")]
     [DataContract]
-    public partial class Instant : PrimitiveType<DateTimeOffset?>, INullableValue<DateTimeOffset>
+    public partial class Instant : PrimitiveType, INullableValue<DateTimeOffset>
     {
         public override string TypeName { get { return "instant"; } }
         

--- a/src/Hl7.Fhir.Support.Poco/Model/Integer.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Integer.cs
@@ -45,7 +45,7 @@ namespace Hl7.Fhir.Model
     [System.Diagnostics.DebuggerDisplay(@"\{Value={Value}}")]
     [FhirType("integer")]
     [DataContract]
-    public class Integer : PrimitiveType<int?>, INullableIntegerValue
+    public class Integer : PrimitiveType, INullableIntegerValue
     {
         public override string TypeName { get { return "integer"; } }
         

--- a/src/Hl7.Fhir.Support.Poco/Model/Integer64.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Integer64.cs
@@ -45,7 +45,7 @@ namespace Hl7.Fhir.Model
     [System.Diagnostics.DebuggerDisplay(@"\{Value={Value}}")]
     [FhirType("integer64")]
     [DataContract]
-    public partial class Integer64 : Hl7.Fhir.Model.PrimitiveType<long?>, INullableValue<long>
+    public partial class Integer64 : PrimitiveType, INullableValue<long>
     {
         [NotMapped]
         public override string TypeName { get { return "integer64"; } }

--- a/src/Hl7.Fhir.Support.Poco/Model/Markdown.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Markdown.cs
@@ -46,7 +46,7 @@ namespace Hl7.Fhir.Model
 
     [FhirType("markdown")]
     [DataContract]
-    public partial class Markdown : Hl7.Fhir.Model.PrimitiveType<string>, IStringValue
+    public partial class Markdown : PrimitiveType, IStringValue
     {
         public override string TypeName { get { return "markdown"; } }
 

--- a/src/Hl7.Fhir.Support.Poco/Model/Oid.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Oid.cs
@@ -46,7 +46,7 @@ namespace Hl7.Fhir.Model
 
     [FhirType("oid")]
     [DataContract]
-    public class Oid : PrimitiveType<string>, IStringValue
+    public class Oid : PrimitiveType, IStringValue
     {
         public override string TypeName { get { return "oid"; } }
 

--- a/src/Hl7.Fhir.Support.Poco/Model/PositiveInt.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/PositiveInt.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
     [System.Diagnostics.DebuggerDisplay(@"\{Value={Value}}")]
     [FhirType("positiveInt")]
     [DataContract]
-    public partial class PositiveInt : PrimitiveType<int?>, INullableIntegerValue
+    public partial class PositiveInt : PrimitiveType, INullableIntegerValue
     {
         public override string TypeName { get { return "positiveInt"; } }
         

--- a/src/Hl7.Fhir.Support.Poco/Model/PrimitiveType.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/PrimitiveType.cs
@@ -20,19 +20,6 @@ namespace Hl7.Fhir.Model
 #if !NETSTANDARD1_1
     [Serializable]
 #endif
-    public abstract class PrimitiveType<T> : PrimitiveType
-    {
-        // [WMR 20160615] Cannot provide common generic Value property, as subclasses differ in their implementation
-        // e.g. Code<T> exposes T? Value where T : struct
-        // T Value { get; set; }
-        // => Instead, define and implement a generic interface IValue<T>
-    }
-
-
-
-#if !NETSTANDARD1_1
-    [Serializable]
-#endif
     [FhirType("PrimitiveType")]
     [DataContract]
     public abstract class PrimitiveType : DataType

--- a/src/Hl7.Fhir.Support.Poco/Model/Time.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Time.cs
@@ -45,7 +45,7 @@ namespace Hl7.Fhir.Model
     [System.Diagnostics.DebuggerDisplay(@"\{Value={Value}}")]
     [FhirType("time")]
     [DataContract]
-    public partial class Time : PrimitiveType<string>, IStringValue
+    public partial class Time : PrimitiveType, IStringValue
     {
         public override string TypeName { get { return "time"; } }
 

--- a/src/Hl7.Fhir.Support.Poco/Model/UnsignedInt.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/UnsignedInt.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
 
     [FhirType("unsignedInt")]
     [DataContract]
-    public partial class UnsignedInt : PrimitiveType<int?>, INullableIntegerValue
+    public partial class UnsignedInt : PrimitiveType, INullableIntegerValue
     {
         public override string TypeName { get { return "unsignedInt"; } }
 

--- a/src/Hl7.Fhir.Support.Poco/Model/Uuid.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Uuid.cs
@@ -46,7 +46,7 @@ namespace Hl7.Fhir.Model
     [System.Diagnostics.DebuggerDisplay(@"\{Value={Value}}")]
     [FhirType("uuid")]
     [DataContract]
-    public class Uuid : PrimitiveType<string>, IStringValue
+    public class Uuid : PrimitiveType, IStringValue
     {
         public override string TypeName { get { return "uuid"; } }
         

--- a/src/Hl7.Fhir.Support.Poco/Model/XHtml.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/XHtml.cs
@@ -51,7 +51,7 @@ namespace Hl7.Fhir.Model
     [System.Diagnostics.DebuggerDisplay(@"\{Value={Value}}")]
     [FhirType("xhtml")]
     [DataContract]
-    public class XHtml : PrimitiveType<string>, IStringValue
+    public class XHtml : PrimitiveType, IStringValue
     {
         public override string TypeName { get { return "xhtml"; } }
 


### PR DESCRIPTION
Primitive<T> was an empty abstract type and did not have a function anymore. 