### PR TITLE
fix: removed  LastStatusCode, LastResponse and LastReqeuest from Requesters

### DIFF
--- a/src/Hl7.Fhir.Support.Poco/Rest/EntryResponse.cs
+++ b/src/Hl7.Fhir.Support.Poco/Rest/EntryResponse.cs
@@ -22,8 +22,6 @@ namespace Hl7.Fhir.Rest
         public byte[] Body { get; set; }
         public string Location { get; set; }
         public Uri ResponseUri { get; set; } 
-        public object LastResponse { get; set; }
-        public object LastRequest { get; set; }
 
         public EntryResponse()
         {

--- a/src/Hl7.Fhir.Support.Poco/Rest/EntryToTypedElementExtensions.cs
+++ b/src/Hl7.Fhir.Support.Poco/Rest/EntryToTypedElementExtensions.cs
@@ -16,6 +16,7 @@ namespace Hl7.Fhir.Rest
                 Body = response.Body,
                 Etag = response.Etag,
                 Headers = response.Headers,
+                LastModified = response.LastModified,
                 Location = response.Location,
                 ResponseUri = response.ResponseUri,
                 Status = response.Status

--- a/src/Hl7.Fhir.Support.Poco/Rest/EntryToTypedElementExtensions.cs
+++ b/src/Hl7.Fhir.Support.Poco/Rest/EntryToTypedElementExtensions.cs
@@ -16,9 +16,6 @@ namespace Hl7.Fhir.Rest
                 Body = response.Body,
                 Etag = response.Etag,
                 Headers = response.Headers,
-                LastModified = response.LastModified,
-                LastRequest = response.LastRequest,
-                LastResponse = response.LastResponse,
                 Location = response.Location,
                 ResponseUri = response.ResponseUri,
                 Status = response.Status

--- a/src/Hl7.Fhir.Support.Poco/Rest/HttpToEntryExtensions.cs
+++ b/src/Hl7.Fhir.Support.Poco/Rest/HttpToEntryExtensions.cs
@@ -66,11 +66,13 @@ namespace Hl7.Fhir.Rest
                 return null;
         }
 
-        internal static EntryResponse ToEntryResponse(this HttpWebResponse response, byte[] body, ref EntryResponse result)
+        internal static EntryResponse ToEntryResponse(this HttpWebResponse response, byte[] body)
         {
-            result = result ?? new EntryResponse();
+            var result = new EntryResponse
+            {
+                Status = ((int)response.StatusCode).ToString()
+            };
 
-            result.Status = ((int)response.StatusCode).ToString();
             foreach (var key in response.Headers.AllKeys)
             {
                 result.Headers.Add(key, response.Headers[key]);

--- a/src/Hl7.Fhir.Support.Poco/Rest/Legacy/WebClientRequester.cs
+++ b/src/Hl7.Fhir.Support.Poco/Rest/Legacy/WebClientRequester.cs
@@ -50,11 +50,6 @@ namespace Hl7.Fhir.Rest
                 request.Headers["Accept-Encoding"] = "gzip, deflate";
             }
 
-            var result = new EntryResponse
-            {
-                LastRequest = request
-            };
-
             BeforeRequest?.Invoke(request, interaction.RequestBodyContent);
 
             // Write the body to the output
@@ -68,12 +63,10 @@ namespace Hl7.Fhir.Rest
                 {
                     //Read body before we call the hook, so the hook cannot read the body before we do
                     var inBody = readBody(webResponse);
-
-                    result.LastResponse = webResponse;
                     AfterResponse?.Invoke(webResponse, inBody);
+                    
+                    return webResponse.ToEntryResponse(inBody);
 
-                    webResponse.ToEntryResponse(inBody, ref result);
-                    return result;
                 }
                 catch (AggregateException ae)
                 {


### PR DESCRIPTION
Removed LastResponse and LastRequest from the FhirClient, therefor this code in  the requesters was obsolete.