### PR TITLE
fix: #884 %resource confusion

### DIFF
--- a/src/Hl7.FhirPath/FhirPath/EvaluationContext.cs
+++ b/src/Hl7.FhirPath/FhirPath/EvaluationContext.cs
@@ -13,18 +13,36 @@ namespace Hl7.FhirPath
             // no defaults yet
         }
 
-        public EvaluationContext(ITypedElement container) : this(container, null) { }
+        /// <summary>
+        /// Create an EvaluationContext with the given value for <c>%resource</c>.
+        /// </summary>
+        /// <param name="resource">The data that will be represented by %resource</param>
+        public EvaluationContext(ITypedElement resource) : this(resource, null) { }
 
-        public EvaluationContext(ITypedElement container, ITypedElement rootContainer)
+        /// <summary>
+        /// Create an EvaluationContext with the given value for <c>%resource</c> and <c>%rootResource</c>.
+        /// </summary>
+        /// <param name="resource">The data that will be represented by <c>%resource</c>.</param>
+        /// <param name="rootResource">The data that will be represented by <c>%rootResource</c>.</param>
+        public EvaluationContext(ITypedElement resource, ITypedElement rootResource)
         {
-            Container = container;
-            RootContainer = rootContainer ?? container;
+            Resource = resource;
+            RootResource = rootResource ?? resource;
         }
 
-        public ITypedElement RootContainer { get; set; }
+        /// <summary>
+        /// The data represented by <c>%rootResource</c>.
+        /// </summary>
+        public ITypedElement RootResource { get; set; }
 
-        public ITypedElement Container { get; set; }
+        /// <summary>
+        /// The data represented by <c>%resource</c>.
+        /// </summary>
+        public ITypedElement Resource { get; set; }
 
+        /// <summary>
+        /// A delegate that handles the output for the <c>trace()</c> function.
+        /// </summary>
         public Action<string, IEnumerable<ITypedElement>> Tracer { get; set; }
 
         #region Obsolete members
@@ -34,7 +52,7 @@ namespace Hl7.FhirPath
         [Obsolete("Use EvaluationContext(ITypedElement container) instead. Obsolete since 2018-10-17")]
         public EvaluationContext(IElementNavigator container)
         {
-            Container = container.ToTypedElement();
+            Resource = container.ToTypedElement();
         }
 
         #endregion

--- a/src/Hl7.FhirPath/FhirPath/Expressions/Closure.cs
+++ b/src/Hl7.FhirPath/FhirPath/Expressions/Closure.cs
@@ -28,8 +28,8 @@ namespace Hl7.FhirPath.Expressions
             newContext.SetThis(input);
             newContext.SetThat(input);
             newContext.SetOriginalContext(input);
-            if (ctx.Container != null) newContext.SetResource(new[] { ctx.Container });
-            if (ctx.RootContainer != null) newContext.SetRootResource(new[] { ctx.RootContainer });
+            if (ctx.Resource != null) newContext.SetResource(new[] { ctx.Resource });
+            if (ctx.RootResource != null) newContext.SetRootResource(new[] { ctx.RootResource });
 
             return newContext;
         }

--- a/src/Hl7.FhirPath/FhirPath/Expressions/ClosureExtensions.cs
+++ b/src/Hl7.FhirPath/FhirPath/Expressions/ClosureExtensions.cs
@@ -34,10 +34,33 @@ namespace Hl7.FhirPath.Expressions
             ctx.SetValue("builtin.that", value);
         }
 
+        /// <summary>
+        /// The original node that was passed to the evaluation engine before starting evaluation.
+        /// </summary>
         public static void SetOriginalContext(this Closure ctx, IEnumerable<ITypedElement> value)
         {
             ctx.SetValue("context", value);
         }
+
+        /// <summary>
+        /// The original resource current context is part of. When evaluating a datatype, this would be the
+        /// resource the element is part of. Do not go past a root resource into a bundle, if it is contained
+        /// in a bundle.
+        /// </summary>
+        public static void SetResource(this Closure ctx, IEnumerable<ITypedElement> value)
+        {
+            ctx.SetValue("resource", value);
+        }
+
+        /// <summary>
+        /// When a DomainResource contains another resource, and that contained resource is the focus (%resource) 
+        /// then %rootResource refers to the container resource.
+        /// </summary>
+        public static void SetRootResource(this Closure ctx, IEnumerable<ITypedElement> value)
+        {
+            ctx.SetValue("rootResource", value);
+        }
+
 
         public static IEnumerable<ITypedElement> GetOriginalContext(this Closure ctx)
         {
@@ -49,19 +72,10 @@ namespace Hl7.FhirPath.Expressions
             return ctx.ResolveValue("resource");
         }
 
-        public static void SetResource(this Closure ctx, IEnumerable<ITypedElement> value)
-        {
-            ctx.SetValue("resource", value);
-        }
 
         public static IEnumerable<ITypedElement> GetRootResource(this Closure ctx)
         {
             return ctx.ResolveValue("rootResource");
-        }
-
-        public static void SetRootResource(this Closure ctx, IEnumerable<ITypedElement> value)
-        {
-            ctx.SetValue("rootResource", value);
         }
 
         public static Closure Nest(this Closure ctx, IEnumerable<ITypedElement> input)


### PR DESCRIPTION
The differences between %context, %resource and %rootResource were not clear - added comments to the properties representing them, even renamed some. Then made sure validator passed in the right values to these FhirPath variables.
