### PR TITLE
long should be serialized as string in Json

### DIFF
--- a/src/Hl7.Fhir.Serialization/FhirJsonBuilder.cs
+++ b/src/Hl7.Fhir.Serialization/FhirJsonBuilder.cs
@@ -8,7 +8,6 @@
 
 
 using Hl7.Fhir.ElementModel;
-using Hl7.Fhir.Language;
 using Hl7.Fhir.Specification;
 using Hl7.Fhir.Utility;
 using Newtonsoft.Json.Linq;
@@ -94,7 +93,7 @@ namespace Hl7.Fhir.Serialization
              "url",
              "markdown",
              "base64Binary",
-             "xhtml" 
+             "xhtml"
         };
 
 
@@ -210,13 +209,13 @@ namespace Hl7.Fhir.Serialization
                 case Int32 i32:
                 case Int16 i16:
                 case ulong ul:
-                case long l:
                 case double db:
                 case BigInteger bi:
                 case float f:
                     return new JValue(value);
                 case string s:
-                    return new JValue(s.Trim());                
+                    return new JValue(s.Trim());
+                case long l:
                 default:
                     return new JValue(PrimitiveTypeConverter.ConvertTo<string>(value));
             }


### PR DESCRIPTION
fix: long should be serialized as string in Json. Long (integer64) is introduced in R5.